### PR TITLE
feat: add relation pushforward transport

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -77,7 +77,7 @@
     "real.triangular_sum": "233d44e2ede6c7b2278d8c071b84b79bf98cef0d4a608cd3e0df47d175121cfb",
     "relation": "be09d2c2e6cc9476149617d306955e6ff8c834c86eb8082b81b7a11d9a74fb2d",
     "relation_basic": "4b81bfe420a92c4d21073062e633b61db1572448ac1935a11ce8d66dbe078b80",
-    "relation_transport": "25d1c71a2d5abefd81873366926c61cce173b90b02617487a2afc279384009e9",
+    "relation_transport": "68c37ddce95026bb77bd9efb56eaec3bc92912d7ce6476cae28fe14ee6cea69a",
     "ring": "ca879591091e736df94f2fea9ad637a5a3b5f53fc9331105469a347d9727da4c",
     "semigroup": "fe447410f73ecf26812d523903d89bd4e8fc9f57abf4b6326c1d96b97efd0935",
     "semiring": "a9e2a52a901c480363ff641631c280bdbbf6fe964eda9fb83b22cd0d4eb5fcb5",

--- a/build/relation_transport.jsonl
+++ b/build/relation_transport.jsonl
@@ -1,3 +1,140 @@
+{"goal":"exists(k0: A, k1: A) { k0 = x and k1 = y and f(k0) = f(x) and f(k1) = f(y) and r(k0, k1) }","proof":[]}
+{"goal":"relation_pushforward[A, B](f, r, f(x), f(y))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T1, x3: (T0, T0) -> Bool) { exists(k0: T0, k1: T0) { x0(k0) = x1 and x0(k1) = x2 and x3(k0, k1) } = relation_pushforward[T0, T1](x0, x3, x1, x2) }[A, B](f, f(x), f(y), r)"]}
+{"goal":"relation_pushforward_intro","proof":[]}
+{"goal":"exists(k0: A, k1: A) { f(k0) = u and f(k1) = v and r(k0, k1) }","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T1, x3: (T0, T0) -> Bool) { exists(k0: T0, k1: T0) { x0(k0) = x1 and x0(k1) = x2 and x3(k0, k1) } = relation_pushforward[T0, T1](x0, x3, x1, x2) }[A, B](f, u, v, r)"]}
+{"goal":"relation_pushforward_has_preimages","proof":[]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = u and f(k1) = v and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x) = u and f(k0) = v and r(x, k0) }","proof":[]}
+{"goal":"s(x, y)","proof":[]}
+{"goal":"exists(k0: A, k1: A) { k0 = x and k1 = y and f(k0) = u and f(k1) = v and s(k0, k1) }","proof":[]}
+{"goal":"relation_pushforward[A, B](f, s, u, v)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T1, x3: (T0, T0) -> Bool) { exists(k0: T0, k1: T0) { x0(k0) = x1 and x0(k1) = x2 and x3(k0, k1) } = relation_pushforward[T0, T1](x0, x3, x1, x2) }[A, B](f, u, v, s)","f(x) = u and f(y) = v","not exists(k0: A, k1: A) { f(k0) = u and f(k1) = v and s(k0, k1) }","function(x0: A) { not exists(k0: A) { f(x0) = u and f(k0) = v and s(x0, k0) } }(x)","function(x0: A, x1: A) { not (f(x0) = u and f(x1) = v and s(x0, x1)) }(x, y)"]}
+{"goal":"relation_pushforward_monotone","proof":["function[T0, T1](x0: (T0, T1) -> Bool, x1: (T0, T1) -> Bool) { forall(x2: T0, x3: T1) { not x0(x2, x3) or x1(x2, x3) } = relation_subset[T0, T1](x0, x1) }[B, B](relation_pushforward[A, B](f, r), relation_pushforward[A, B](f, s))"]}
+{"goal":"exists(k0: T) { exists(k1: T) { identity_fn(k0) = x and identity_fn(k1) = y and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: T) { identity_fn(a) = x and identity_fn(k0) = y and r(a, k0) }","proof":[]}
+{"goal":"identity_fn(a) = a","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](a)"]}
+{"goal":"identity_fn(b) = b","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](b)"]}
+{"goal":"a = x","proof":[]}
+{"goal":"b = y","proof":[]}
+{"goal":"r(x, y)","proof":[]}
+{"goal":"identity_fn(x) = x","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](x)"]}
+{"goal":"identity_fn(y) = y","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](y)"]}
+{"goal":"u(x, y)","proof":[]}
+{"goal":"u(x, y) = r(x, y)","proof":[]}
+{"goal":"relation_pushforward_identity","proof":[]}
+{"goal":"exists(k0: A) { exists(k1: A) { compose[A, B, C](f, g)(k0) = p and compose[A, B, C](f, g)(k1) = q and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { compose[A, B, C](f, g)(x) = p and compose[A, B, C](f, g)(k0) = q and r(x, k0) }","proof":[]}
+{"goal":"compose[A, B, C](f, g, x) = f(g(x))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](f, g, x)"]}
+{"goal":"compose[A, B, C](f, g, y) = f(g(y))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](f, g, y)"]}
+{"goal":"f(g(x)) = p","proof":[]}
+{"goal":"f(g(y)) = q","proof":[]}
+{"goal":"relation_pushforward[A, B](g, r, g(x), g(y))","proof":[]}
+{"goal":"exists(k0: B, k1: B) { k0 = g(x) and k1 = g(y) and f(k0) = p and f(k1) = q and relation_pushforward[A, B](g, r, k0, k1) }","proof":[]}
+{"goal":"relation_pushforward[B, C](f, relation_pushforward[A, B](g, r), p, q)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T1, x3: (T0, T0) -> Bool) { exists(k0: T0, k1: T0) { x0(k0) = x1 and x0(k1) = x2 and x3(k0, k1) } = relation_pushforward[T0, T1](x0, x3, x1, x2) }[B, C](f, p, q, relation_pushforward[A, B](g, r))","not exists(k0: B, k1: B) { f(k0) = p and f(k1) = q and relation_pushforward[A, B](g, r, k0, k1) }","function(x0: B) { not exists(k0: B) { f(x0) = p and f(k0) = q and relation_pushforward[A, B](g, r, x0, k0) } }(g(x))","function(x0: B, x1: B) { not (f(x0) = p and f(x1) = q and relation_pushforward[A, B](g, r, x0, x1)) }(g(x), g(y))"]}
+{"goal":"v(p, q)","proof":[]}
+{"goal":"exists(k0: B) { exists(k1: B) { f(k0) = p and f(k1) = q and relation_pushforward[A, B](g, r, k0, k1) } }","proof":[]}
+{"goal":"exists(k0: B) { f(a) = p and f(k0) = q and relation_pushforward[A, B](g, r, a, k0) }","proof":[]}
+{"goal":"exists(k0: A) { exists(k1: A) { g(k0) = a and g(k1) = b and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { g(x) = a and g(k0) = b and r(x, k0) }","proof":[]}
+{"goal":"compose[A, B, C](f, g, x) = f(g(x))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](f, g, x)"]}
+{"goal":"compose[A, B, C](f, g, y) = f(g(y))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](f, g, y)"]}
+{"goal":"compose[A, B, C](f, g)(x) = p","proof":[]}
+{"goal":"compose[A, B, C](f, g)(y) = q","proof":[]}
+{"goal":"f(g(x)) = p","proof":[]}
+{"goal":"f(g(y)) = q","proof":[]}
+{"goal":"exists(k0: A, k1: A) { k0 = x and k1 = y and compose[A, B, C](f, g)(k0) = p and compose[A, B, C](f, g)(k1) = q and r(k0, k1) }","proof":[]}
+{"goal":"relation_pushforward[A, C](compose[A, B, C](f, g), r, p, q)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T1, x3: (T0, T0) -> Bool) { exists(k0: T0, k1: T0) { x0(k0) = x1 and x0(k1) = x2 and x3(k0, k1) } = relation_pushforward[T0, T1](x0, x3, x1, x2) }[A, C](compose[A, B, C](f, g), p, q, r)","r(x, y)","not exists(k0: A, k1: A) { compose[A, B, C](f, g, k0) = p and compose[A, B, C](f, g, k1) = q and r(k0, k1) }","function(x0: A) { not exists(k0: A) { compose[A, B, C](f, g, x0) = p and compose[A, B, C](f, g, k0) = q and r(x0, k0) } }(x)","function(x0: A, x1: A) { not (compose[A, B, C](f, g, x0) = p and compose[A, B, C](f, g, x1) = q and r(x0, x1)) }(x, y)"]}
+{"goal":"u(p, q)","proof":[]}
+{"goal":"u(p, q) = v(p, q)","proof":[]}
+{"goal":"relation_pushforward_compose","proof":[]}
+{"goal":"exists(k0: A) { f(k0) = u }","proof":[]}
+{"goal":"relation_pushforward[A, B](f, r, u, u)","proof":[]}
+{"goal":"relation_pushforward_is_reflexive_of_surjective","proof":["function[T0](x0: (T0, T0) -> Bool) { forall(x1: T0) { x0(x1, x1) } = is_reflexive[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = u and f(k1) = v and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x) = u and f(k0) = v and r(x, k0) }","proof":[]}
+{"goal":"r(y, x)","proof":[]}
+{"goal":"exists(k0: A, k1: A) { k0 = y and k1 = x and f(k0) = v and f(k1) = u and r(k0, k1) }","proof":[]}
+{"goal":"relation_pushforward[A, B](f, r, v, u)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T1, x3: (T0, T0) -> Bool) { exists(k0: T0, k1: T0) { x0(k0) = x1 and x0(k1) = x2 and x3(k0, k1) } = relation_pushforward[T0, T1](x0, x3, x1, x2) }[A, B](f, v, u, r)","f(x) = u and f(y) = v","not exists(k0: A, k1: A) { f(k0) = v and f(k1) = u and r(k0, k1) }","function(x0: A) { not exists(k0: A) { f(x0) = v and f(k0) = u and r(x0, k0) } }(y)","function(x0: A, x1: A) { not (f(x0) = v and f(x1) = u and r(x0, x1)) }(y, x)"]}
+{"goal":"relation_pushforward_is_symmetric","proof":["function[T0](x0: (T0, T0) -> Bool) { forall(x1: T0, x2: T0) { not x0(x1, x2) or x0(x2, x1) } = is_symmetric[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = u and f(k1) = v and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x1) = u and f(k0) = v and r(x1, k0) }","proof":[]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = v and f(k1) = w and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x2) = v and f(k0) = w and r(x2, k0) }","proof":[]}
+{"goal":"f(y1) = f(x2)","proof":[]}
+{"goal":"y1 = x2","proof":[]}
+{"goal":"r(x1, x2)","proof":[]}
+{"goal":"r(x1, y2)","proof":[]}
+{"goal":"exists(k0: A, k1: A) { k0 = x1 and k1 = y2 and f(k0) = u and f(k1) = w and r(k0, k1) }","proof":[]}
+{"goal":"relation_pushforward[A, B](f, r, u, w)","proof":["function[T0, T1](x0: T0 -> T1, x3: T1, x4: T1, x5: (T0, T0) -> Bool) { exists(k0: T0, k1: T0) { x0(k0) = x3 and x0(k1) = x4 and x5(k0, k1) } = relation_pushforward[T0, T1](x0, x5, x3, x4) }[A, B](f, u, w, r)","f(x1) = u and f(y1) = v","f(x2) = v and f(y2) = w","not exists(k0: A, k1: A) { f(k0) = u and f(k1) = w and r(k0, k1) }","function(x0: A) { not exists(k0: A) { f(x0) = u and f(k0) = w and r(x0, k0) } }(x1)","function(x0: A, x3: A) { not (f(x0) = u and f(x3) = w and r(x0, x3)) }(x1, y2)"]}
+{"goal":"relation_pushforward_is_transitive_of_injective","proof":["function[T0](x0: (T0, T0) -> Bool) { forall(x1: T0, x2: T0, x3: T0) { not x0(x1, x2) or not x0(x2, x3) or x0(x1, x3) } = is_transitive[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"is_total[A](r) = forall(x0: A, x1: A) { r(x0, x1) or r(x1, x0) }","proof":["function[T0](x0: (T0, T0) -> Bool) { forall(x1: T0, x2: T0) { x0(x1, x2) or x0(x2, x1) } = is_total[T0](x0) }[A](r)"]}
+{"goal":"exists(k0: A) { f(k0) = u }","proof":[]}
+{"goal":"exists(k0: A) { f(k0) = v }","proof":[]}
+{"goal":"r(x, y) or r(y, x)","proof":["is_total[A](r)","(forall(x0: A, x1: A) { r(x0, x1) or r(x1, x0) } = true)","function(x0: A) { forall(x1: A) { r(x0, x1) or r(x1, x0) } = true }(x)","function(x0: A, x1: A) { not (not r(x0, x1) and not r(x1, x0)) }(x, y)"]}
+{"goal":"relation_pushforward[A, B](f, r, u, v)","proof":[]}
+{"goal":"relation_pushforward[A, B](f, r, u, v) or relation_pushforward[A, B](f, r, v, u)","proof":[]}
+{"goal":"relation_pushforward[A, B](f, r, v, u)","proof":[]}
+{"goal":"relation_pushforward[A, B](f, r, u, v) or relation_pushforward[A, B](f, r, v, u)","proof":[]}
+{"goal":"relation_pushforward_is_total_of_surjective","proof":["function[T0](x0: (T0, T0) -> Bool) { forall(x1: T0, x2: T0) { x0(x1, x2) or x0(x2, x1) } = is_total[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = u and f(k1) = v and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x1) = u and f(k0) = v and r(x1, k0) }","proof":[]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = v and f(k1) = u and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x2) = v and f(k0) = u and r(x2, k0) }","proof":[]}
+{"goal":"f(y1) = f(x2)","proof":[]}
+{"goal":"y1 = x2","proof":[]}
+{"goal":"f(x1) = f(y2)","proof":[]}
+{"goal":"x1 = y2","proof":[]}
+{"goal":"r(y1, x1)","proof":[]}
+{"goal":"x1 = y1","proof":[]}
+{"goal":"f(x1) = f(y1)","proof":[]}
+{"goal":"u = v","proof":[]}
+{"goal":"relation_pushforward_is_antisymmetric_of_injective","proof":["function[T0](x0: (T0, T0) -> Bool) { forall(x1: T0, x2: T0) { not x0(x1, x2) or not x0(x2, x1) or x2 = x1 } = is_antisymmetric[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"is_surjective_fn[A, B](f)","proof":[]}
+{"goal":"is_reflexive[A](r)","proof":[]}
+{"goal":"is_reflexive[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"is_symmetric[A](r)","proof":[]}
+{"goal":"is_symmetric[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"is_injective_fn[A, B](f)","proof":[]}
+{"goal":"is_transitive[A](r)","proof":[]}
+{"goal":"is_transitive[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"is_equivalence[B](relation_pushforward[A, B](f, r))","proof":["function[T0](x0: (T0, T0) -> Bool) { (is_reflexive[T0](x0) and is_symmetric[T0](x0) and is_transitive[T0](x0)) = is_equivalence[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"relation_pushforward_is_equivalence_of_bijection","proof":[]}
+{"goal":"is_surjective_fn[A, B](f)","proof":[]}
+{"goal":"is_reflexive[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"is_injective_fn[A, B](f)","proof":[]}
+{"goal":"is_transitive[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"is_antisymmetric[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"is_reflexive[B](relation_pushforward[A, B](f, r)) and is_transitive[B](relation_pushforward[A, B](f, r)) and is_antisymmetric[B](relation_pushforward[A, B](f, r))","proof":["not is_reflexive[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"relation_pushforward_is_reflexive_transitive_antisymmetric_of_bijection","proof":["is_antisymmetric[A](r)","is_bijection_fn[A, B](f) and is_reflexive[A](r) and is_transitive[A](r)","is_reflexive[A](r)","is_bijection_fn[A, B](f)","is_reflexive[B](relation_pushforward[A, B](f, r)) and is_transitive[B](relation_pushforward[A, B](f, r)) and is_antisymmetric[B](relation_pushforward[A, B](f, r))","not is_transitive[B](relation_pushforward[A, B](f, r)) or not is_reflexive[B](relation_pushforward[A, B](f, r))","is_transitive[B](relation_pushforward[A, B](f, r))","is_reflexive[B](relation_pushforward[A, B](f, r))","not is_reflexive[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y)","proof":["function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, relation_pushforward[A, B](f, r), x, y)"]}
+{"goal":"relation_subset_pullback_pushforward","proof":["function[T0, T1](x0: (T0, T1) -> Bool, x1: (T0, T1) -> Bool) { forall(x2: T0, x3: T1) { not x0(x2, x3) or x1(x2, x3) } = relation_subset[T0, T1](x0, x1) }[A, A](r, relation_pullback[A, B](f, relation_pushforward[A, B](f, r)))","let w0: A satisfy { exists(k0: A) { r(w0, k0) and not relation_pullback[A, B](f, relation_pushforward[A, B](f, r), w0, k0) } }","let w1: A satisfy { r(w0, w1) and not relation_pullback[A, B](f, relation_pushforward[A, B](f, r), w0, w1) }","function(x0: A, x1: A) { not r(x0, x1) or relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x0, x1) }(w0, w1)"]}
+{"goal":"relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y) = relation_pushforward[A, B](f, r, f(x), f(y))","proof":["function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, relation_pushforward[A, B](f, r), x, y)"]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = f(x) and f(k1) = f(y) and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(a) = f(x) and f(k0) = f(y) and r(a, k0) }","proof":[]}
+{"goal":"a = x","proof":[]}
+{"goal":"b = y","proof":[]}
+{"goal":"r(x, y)","proof":[]}
+{"goal":"relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y)","proof":["function[T0, T4](x0: (T0, T0) -> Bool, x1: T0, x2: T0, x3: T0 -> T4) { not x0(x1, x2) or relation_pushforward[T0, T4](x3, x0, x3(x1), x3(x2)) }[A, B](r, x, y, f)","function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, relation_pushforward[A, B](f, r), x, y)"]}
+{"goal":"relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y) = r(x, y)","proof":["relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y) or r(x, y)","r(x, y)","relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y)","not relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y)"]}
+{"goal":"relation_pullback_pushforward_of_injective_at","proof":["not is_injective_fn[A, B](f)"]}
+{"goal":"u(x, y) = r(x, y)","proof":[]}
+{"goal":"relation_pullback_pushforward_of_injective","proof":["let w0: A satisfy { r(w0) != relation_pullback[A, B](f, relation_pushforward[A, B](f, r), w0) }","let w1: A satisfy { r(w0, w1) != relation_pullback[A, B](f, relation_pushforward[A, B](f, r), w0, w1) }","function[T0, T1](x0: T0 -> T1, x1: (T0, T0) -> Bool, x2: T0, x3: T0) { not is_injective_fn[T0, T1](x0) or relation_pullback[T0, T1](x0, relation_pushforward[T0, T1](x0, x1), x2, x3) = x1(x2, x3) }[A, B](f, r, w0, w1)"]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = u and f(k1) = v and relation_pullback[A, B](f, r, k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x) = u and f(k0) = v and relation_pullback[A, B](f, r, x, k0) }","proof":[]}
+{"goal":"relation_pullback[A, B](f, r, x, y) = r(f(x), f(y))","proof":["function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, r, x, y)"]}
+{"goal":"r(f(x), f(y))","proof":[]}
+{"goal":"r(u, v)","proof":[]}
+{"goal":"relation_subset_pushforward_pullback","proof":["function[T0, T1](x0: (T0, T1) -> Bool, x1: (T0, T1) -> Bool) { forall(x2: T0, x3: T1) { not x0(x2, x3) or x1(x2, x3) } = relation_subset[T0, T1](x0, x1) }[B, B](relation_pushforward[A, B](f, relation_pullback[A, B](f, r)), r)","let w0: B satisfy { exists(k0: B) { relation_pushforward[A, B](f, relation_pullback[A, B](f, r), w0, k0) and not r(w0, k0) } }","let w1: B satisfy { relation_pushforward[A, B](f, relation_pullback[A, B](f, r), w0, w1) and not r(w0, w1) }","function(x0: B, x1: B) { not relation_pushforward[A, B](f, relation_pullback[A, B](f, r), x0, x1) or r(x0, x1) }(w0, w1)"]}
+{"goal":"r(p, q)","proof":["function[T0, T1](x0: (T0, T1) -> Bool, x1: (T0, T1) -> Bool, x2: T0, x3: T1) { not relation_subset[T0, T1](x0, x1) or not x0(x2, x3) or x1(x2, x3) }[B, B](relation_pushforward[A, B](f, relation_pullback[A, B](f, r)), r, p, q)","function(x0: (B, B) -> Bool) { not relation_subset[B, B](x0, r) or not x0(p, q) }(relation_pushforward[A, B](f, relation_pullback[A, B](f, r)))"]}
+{"goal":"exists(k0: A) { f(k0) = p }","proof":[]}
+{"goal":"exists(k0: A) { f(k0) = q }","proof":[]}
+{"goal":"relation_pullback[A, B](f, r, x, y) = r(f(x), f(y))","proof":["function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, r, x, y)"]}
+{"goal":"relation_pullback[A, B](f, r, x, y)","proof":[]}
+{"goal":"exists(k0: A, k1: A) { k0 = x and k1 = y and f(k0) = p and f(k1) = q and relation_pullback[A, B](f, r, k0, k1) }","proof":[]}
+{"goal":"relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T1, x3: (T0, T0) -> Bool) { exists(k0: T0, k1: T0) { x0(k0) = x1 and x0(k1) = x2 and x3(k0, k1) } = relation_pushforward[T0, T1](x0, x3, x1, x2) }[A, B](f, p, q, relation_pullback[A, B](f, r))","not exists(k0: A, k1: A) { f(k0) = p and f(k1) = q and relation_pullback[A, B](f, r, k0, k1) }","function(x0: A) { not exists(k0: A) { f(x0) = p and f(k0) = q and relation_pullback[A, B](f, r, x0, k0) } }(x)","function(x0: A, x1: A) { not (f(x0) = p and f(x1) = q and relation_pullback[A, B](f, r, x0, x1)) }(x, y)"]}
+{"goal":"relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q) = r(p, q)","proof":["relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q) or r(p, q)","r(p, q)","relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q)","not relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q)"]}
+{"goal":"relation_pushforward_pullback_of_surjective_at","proof":["not is_surjective_fn[A, B](f)"]}
+{"goal":"u(p, q) = r(p, q)","proof":[]}
+{"goal":"relation_pushforward_pullback_of_surjective","proof":["let w0: B satisfy { r(w0) != relation_pushforward[A, B](f, relation_pullback[A, B](f, r), w0) }","let w1: B satisfy { r(w0, w1) != relation_pushforward[A, B](f, relation_pullback[A, B](f, r), w0, w1) }","function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T1, x3: T1) { not is_surjective_fn[T0, T1](x0) or relation_pushforward[T0, T1](x0, relation_pullback[T0, T1](x0, x1), x2, x3) = x1(x2, x3) }[A, B](f, r, w0, w1)"]}
 {"goal":"u(x, y) = relation_converse(r, f(x), f(y))","proof":["function(x0: A, x1: A) { relation_pullback[A, B](f, relation_converse[B, B](r), x0, x1) = u(x0, x1) }(x, y)","function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, relation_converse[B, B](r), x, y)"]}
 {"goal":"relation_converse(r, f(x), f(y)) = r(f(y), f(x))","proof":["function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[B, B](r, f(x), f(y))"]}
 {"goal":"v(x, y) = relation_pullback[A, B](f, r, y, x)","proof":["function(x0: A, x1: A) { relation_converse(relation_pullback[A, B](f, r), x0, x1) = v(x0, x1) }(x, y)","function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[A, A](relation_pullback[A, B](f, r), x, y)"]}
@@ -23,26 +160,26 @@
 {"goal":"respects_equivalence[T, U](f, r, s) = relation_subset[T, T](r, relation_pullback[T, U](f, s))","proof":[]}
 {"goal":"respects_equivalence_eq_relation_subset_pullback","proof":[]}
 {"goal":"respects_function[T, U](r, f) = forall(x0: T, x1: T) { r(x0, x1) implies f(x0) = f(x1) }","proof":["function[T0, T2](x0: (T0, T0) -> Bool, x1: T0 -> T2) { forall(x2: T0, x3: T0) { not x0(x2, x3) or x1(x3) = x1(x2) } = respects_function[T0, T2](x0, x1) }[T, U](r, f)"]}
-{"goal":"f(x) = f(y)","proof":["(forall(x0: T, x1: T) { not r(x0, x1) or f(x1) = f(x0) } = true)","function(x0: T) { forall(x1: T) { not r(x0, x1) or f(x0) = f(x1) } = true }(x)","function(x0: T, x1: T) { not (r(x0, x1) and f(x0) != f(x1)) }(x, y)","function(x0: T, x1: T) { not r(x0, x1) or f(x0) = f(x1) }(x, y)"]}
+{"goal":"f(x) = f(y)","proof":["(forall(x0: T, x1: T) { not r(x0, x1) or f(x1) = f(x0) } = true)","function(x0: T) { forall(x1: T) { not r(x0, x1) or f(x0) = f(x1) } = true }(x)","function(x0: T, x1: T) { not (r(x0, x1) and f(x0) != f(x1)) }(x, y)"]}
 {"goal":"eq_relation(f(x), f(y))","proof":["function[T0](x0: T0, x1: T0) { eq_relation[T0](x0, x1) = (x0 = x1) }[U](f(x), f(y))"]}
 {"goal":"respects_equivalence[T, U](f, r, eq_relation[U])","proof":["function[T0, T2](x0: (T0, T0) -> Bool, x1: (T2, T2) -> Bool, x2: T0 -> T2) { forall(x3: T0, x4: T0) { not x0(x3, x4) or x1(x2(x3), x2(x4)) } = respects_equivalence[T0, T2](x2, x0, x1) }[T, U](r, eq_relation[U], f)","(forall(x0: T, x1: T) { not r(x0, x1) or f(x1) = f(x0) } = true)","function[T0] { eq_relation[T0] = (=) }[U]","let w0: T satisfy { exists(k0: T) { r(w0, k0) and not eq_relation(f(w0), f(k0)) } }","function(x0: T) { forall(x1: T) { not r(x0, x1) or f(x0) = f(x1) } = true }(w0)","let w1: T satisfy { r(w0, w1) and not eq_relation(f(w0), f(w1)) }","function(x0: T, x1: T) { not (r(x0, x1) and f(x0) != f(x1)) }(w0, w1)"]}
 {"goal":"respects_equivalence[T, U](f, r, eq_relation[U]) = forall(x0: T, x1: T) { r(x0, x1) implies eq_relation(f(x0), f(x1)) }","proof":["function[T0, T2](x0: (T0, T0) -> Bool, x1: (T2, T2) -> Bool, x2: T0 -> T2) { forall(x3: T0, x4: T0) { not x0(x3, x4) or x1(x2(x3), x2(x4)) } = respects_equivalence[T0, T2](x2, x0, x1) }[T, U](r, eq_relation[U], f)"]}
-{"goal":"eq_relation(f(x), f(y))","proof":["(forall(x0: T, x1: T) { not r(x0, x1) or eq_relation(f(x0), f(x1)) } = true)","function(x0: T) { forall(x1: T) { not r(x0, x1) or eq_relation(f(x0), f(x1)) } = true }(x)","function(x0: T, x1: T) { not (r(x0, x1) and not eq_relation(f(x0), f(x1))) }(x, y)","function(x0: T, x1: T) { not r(x0, x1) or eq_relation(f(x0), f(x1)) }(x, y)"]}
+{"goal":"eq_relation(f(x), f(y))","proof":["(forall(x0: T, x1: T) { not r(x0, x1) or eq_relation(f(x0), f(x1)) } = true)","function(x0: T) { forall(x1: T) { not r(x0, x1) or eq_relation(f(x0), f(x1)) } = true }(x)","function(x0: T, x1: T) { not (r(x0, x1) and not eq_relation(f(x0), f(x1))) }(x, y)"]}
 {"goal":"f(x) = f(y)","proof":["function[T0](x0: T0, x1: T0) { eq_relation[T0](x0, x1) = (x0 = x1) }[U](f(x), f(y))"]}
 {"goal":"respects_function[T, U](r, f)","proof":["function[T0, T2](x0: (T0, T0) -> Bool, x1: T0 -> T2) { forall(x2: T0, x3: T0) { not x0(x2, x3) or x1(x3) = x1(x2) } = respects_function[T0, T2](x0, x1) }[T, U](r, f)","(forall(x0: T, x1: T) { not r(x0, x1) or eq_relation(f(x0), f(x1)) } = true)","function[T0] { eq_relation[T0] = (=) }[U]","let w0: T satisfy { exists(k0: T) { r(w0, k0) and f(k0) != f(w0) } }","function(x0: T) { forall(x1: T) { not r(x0, x1) or eq_relation(f(x0), f(x1)) } = true }(w0)","let w1: T satisfy { r(w0, w1) and f(w1) != f(w0) }","function(x0: T, x1: T) { not (r(x0, x1) and not eq_relation(f(x0), f(x1))) }(w0, w1)"]}
-{"goal":"respects_function[T, U](r, f) = respects_equivalence[T, U](f, r, eq_relation[U])","proof":["respects_equivalence[T, U](f, r, eq_relation[U]) or respects_function[T, U](r, f)","not respects_equivalence[T, U](f, r, eq_relation[U]) or not respects_function[T, U](r, f)","respects_equivalence[T, U](f, r, eq_relation[U])","not respects_equivalence[T, U](f, r, eq_relation[U])"]}
+{"goal":"respects_function[T, U](r, f) = respects_equivalence[T, U](f, r, eq_relation[U])","proof":[]}
 {"goal":"respects_function_eq_respects_equivalence_eq_relation","proof":[]}
 {"goal":"respects_function[T, U](r, f) = forall(x0: T, x1: T) { r(x0, x1) implies f(x0) = f(x1) }","proof":["function[T0, T2](x0: (T0, T0) -> Bool, x1: T0 -> T2) { forall(x2: T0, x3: T0) { not x0(x2, x3) or x1(x3) = x1(x2) } = respects_function[T0, T2](x0, x1) }[T, U](r, f)"]}
-{"goal":"f(x) = f(y)","proof":["r(x, y)","respects_function[T, U](r, f)","(forall(x0: T, x1: T) { not r(x0, x1) or f(x1) = f(x0) } = true)","function(x0: T) { forall(x1: T) { not r(x0, x1) or f(x0) = f(x1) } = true }(x)","function(x0: T, x1: T) { not (r(x0, x1) and f(x0) != f(x1)) }(x, y)","function(x0: T, x1: T) { not r(x0, x1) or f(x0) = f(x1) }(x, y)"]}
-{"goal":"respects_function_step","proof":["not respects_function[T, U](r, f) or not r(x, y)","r(x, y)","respects_function[T, U](r, f)","not respects_function[T, U](r, f)"]}
+{"goal":"f(x) = f(y)","proof":["r(x, y)","respects_function[T, U](r, f)","(forall(x0: T, x1: T) { not r(x0, x1) or f(x1) = f(x0) } = true)","function(x0: T) { forall(x1: T) { not r(x0, x1) or f(x0) = f(x1) } = true }(x)","function(x0: T, x1: T) { not (r(x0, x1) and f(x0) != f(x1)) }(x, y)"]}
+{"goal":"respects_function_step","proof":[]}
 {"goal":"respects_predicate_eq_respects_function","proof":["function[T0](x0: (T0, T0) -> Bool, x1: T0 -> Bool) { respects_function[T0, Bool](x0, x1) = respects_predicate[T0](x0, x1) }[T](r, p)"]}
-{"goal":"respects_predicate_step_eq","proof":["function[T0](x0: (T0, T0) -> Bool, x1: T0 -> Bool) { respects_function[T0, Bool](x0, x1) = respects_predicate[T0](x0, x1) }[T](r, p)","not respects_function[T, Bool](r, p) or not respects_predicate[T](r, p) or not r(x, y)","r(x, y)","respects_predicate[T](r, p)","not respects_function[T, Bool](r, p)"]}
-{"goal":"p(x) = p(y)","proof":["not respects_predicate[T](r, p) or not r(x, y)","respects_predicate[T](r, p) and r(x, y)","not respects_predicate[T](r, p)"]}
-{"goal":"p(y)","proof":["not p(x)"]}
-{"goal":"respects_predicate_forward","proof":["not respects_predicate[T](r, p) or not r(x, y) or not p(x)","p(x)","not respects_predicate[T](r, p) or not r(x, y)","respects_predicate[T](r, p) and r(x, y)","not respects_predicate[T](r, p)"]}
-{"goal":"p(x) = p(y)","proof":["not respects_predicate[T](r, p) or not r(x, y)","respects_predicate[T](r, p) and r(x, y)","not respects_predicate[T](r, p)"]}
-{"goal":"p(x)","proof":["not p(y)"]}
-{"goal":"respects_predicate_backward","proof":["not respects_predicate[T](r, p) or not r(x, y) or not p(y)","p(y)","not respects_predicate[T](r, p) or not r(x, y)","respects_predicate[T](r, p) and r(x, y)","not respects_predicate[T](r, p)"]}
+{"goal":"respects_predicate_step_eq","proof":["function[T0](x0: (T0, T0) -> Bool, x1: T0 -> Bool) { respects_function[T0, Bool](x0, x1) = respects_predicate[T0](x0, x1) }[T](r, p)"]}
+{"goal":"p(x) = p(y)","proof":[]}
+{"goal":"p(y)","proof":[]}
+{"goal":"respects_predicate_forward","proof":[]}
+{"goal":"p(x) = p(y)","proof":[]}
+{"goal":"p(x)","proof":[]}
+{"goal":"respects_predicate_backward","proof":[]}
 {"goal":"u(x, y) = r(identity_fn(x), identity_fn(y))","proof":["function(x0: T, x1: T) { relation_pullback(identity_fn[T], r, x0, x1) = u(x0, x1) }(x, y)","function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[T, T](identity_fn[T], r, x, y)"]}
 {"goal":"identity_fn(x) = x","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](x)"]}
 {"goal":"identity_fn(y) = y","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](y)"]}

--- a/projects/translate-mathlib/foundations/transport-across-equality/todo.md
+++ b/projects/translate-mathlib/foundations/transport-across-equality/todo.md
@@ -3,7 +3,7 @@
 Goal: support moving data and theorems across definitional boundaries in a controlled way.
 
 - [ ] Add basic transport lemmas across equality of types and structures
-- [ ] Add APIs for pushing functions and predicates across equivalences
+- [ ] Extend relation pushforward transport into predicate and function transport across bijections
 - [ ] Add structure-preservation lemmas for transported algebraic data
 - [ ] Add helper lemmas for rewriting bundled objects by equality of underlying data
 - [ ] Add coercion-friendly equivalence wrappers where they reduce proof friction

--- a/src/relation_transport.ac
+++ b/src/relation_transport.ac
@@ -8,6 +8,493 @@ define relation_pullback[A, B](f: A -> B, r: (B, B) -> Bool, x: A, y: A) -> Bool
     r(f(x), f(y))
 }
 
+/// The image of a homogeneous relation along a function.
+define relation_pushforward[A, B](f: A -> B, r: (A, A) -> Bool, u: B, v: B) -> Bool {
+    exists(x: A, y: A) {
+        f(x) = u and f(y) = v and r(x, y)
+    }
+}
+
+/// Related inputs give a related image pair.
+theorem relation_pushforward_intro[A, B](f: A -> B, r: (A, A) -> Bool, x: A, y: A) {
+    r(x, y) implies relation_pushforward(f, r, f(x), f(y))
+} by {
+    if r(x, y) {
+        exists(a: A, b: A) {
+            a = x and b = y and f(a) = f(x) and f(b) = f(y) and r(a, b)
+        }
+        relation_pushforward(f, r, f(x), f(y))
+    }
+}
+
+/// A pushed-forward relation instance has related preimages.
+theorem relation_pushforward_has_preimages[A, B](f: A -> B, r: (A, A) -> Bool, u: B, v: B) {
+    relation_pushforward(f, r, u, v) implies exists(x: A, y: A) {
+        f(x) = u and f(y) = v and r(x, y)
+    }
+} by {
+    if relation_pushforward(f, r, u, v) {
+        exists(x: A, y: A) {
+            f(x) = u and f(y) = v and r(x, y)
+        }
+    }
+}
+
+/// Pushforward is monotone with respect to relation inclusion.
+theorem relation_pushforward_monotone[A, B](f: A -> B, r: (A, A) -> Bool, s: (A, A) -> Bool) {
+    relation_subset(r, s) implies relation_subset(relation_pushforward(f, r), relation_pushforward(f, s))
+} by {
+    if relation_subset(r, s) {
+        forall(u: B, v: B) {
+            if relation_pushforward(f, r, u, v) {
+                relation_pushforward_has_preimages(f, r, u, v)
+                let x: A satisfy {
+                    exists(y: A) {
+                        f(x) = u and f(y) = v and r(x, y)
+                    }
+                }
+                let y: A satisfy {
+                    f(x) = u and f(y) = v and r(x, y)
+                }
+                relation_subset_step(r, s, x, y)
+                s(x, y)
+                exists(a: A, b: A) {
+                    a = x and b = y and f(a) = u and f(b) = v and s(a, b)
+                }
+                relation_pushforward(f, s, u, v)
+            }
+        }
+    }
+}
+
+/// Pushing forward along the identity function leaves a relation unchanged.
+theorem relation_pushforward_identity[T](r: (T, T) -> Bool) {
+    relation_pushforward(identity_fn[T], r) = r
+} by {
+    let u = relation_pushforward(identity_fn[T], r)
+    let v = r
+    forall(x: T, y: T) {
+        if u(x, y) {
+            relation_pushforward_has_preimages(identity_fn[T], r, x, y)
+            let a: T satisfy {
+                exists(b: T) {
+                    identity_fn[T](a) = x and identity_fn[T](b) = y and r(a, b)
+                }
+            }
+            let b: T satisfy {
+                identity_fn[T](a) = x and identity_fn[T](b) = y and r(a, b)
+            }
+            identity_fn[T](a) = a
+            identity_fn[T](b) = b
+            a = x
+            b = y
+            v(x, y)
+        }
+        if v(x, y) {
+            relation_pushforward_intro(identity_fn[T], r, x, y)
+            identity_fn[T](x) = x
+            identity_fn[T](y) = y
+            u(x, y)
+        }
+        u(x, y) = v(x, y)
+    }
+    binary_function_extensionality(u, v)
+}
+
+/// Pushing forward along a composite is the same as pushing forward twice.
+theorem relation_pushforward_compose[A, B, C](g: A -> B, f: B -> C, r: (A, A) -> Bool) {
+    relation_pushforward(compose(f, g), r) = relation_pushforward(f, relation_pushforward(g, r))
+} by {
+    let u = relation_pushforward(compose(f, g), r)
+    let v = relation_pushforward(f, relation_pushforward(g, r))
+    forall(p: C, q: C) {
+        if u(p, q) {
+            relation_pushforward_has_preimages(compose(f, g), r, p, q)
+            let x: A satisfy {
+                exists(y: A) {
+                    compose(f, g)(x) = p and compose(f, g)(y) = q and r(x, y)
+                }
+            }
+            let y: A satisfy {
+                compose(f, g)(x) = p and compose(f, g)(y) = q and r(x, y)
+            }
+            compose(f, g, x) = f(g(x))
+            compose(f, g, y) = f(g(y))
+            f(g(x)) = p
+            f(g(y)) = q
+            relation_pushforward_intro(g, r, x, y)
+            relation_pushforward(g, r, g(x), g(y))
+            exists(a: B, b: B) {
+                a = g(x) and b = g(y) and f(a) = p and f(b) = q and relation_pushforward(g, r, a, b)
+            }
+            relation_pushforward(f, relation_pushforward(g, r), p, q)
+            v(p, q)
+        }
+        if v(p, q) {
+            relation_pushforward_has_preimages(f, relation_pushforward(g, r), p, q)
+            let a: B satisfy {
+                exists(b: B) {
+                    f(a) = p and f(b) = q and relation_pushforward(g, r, a, b)
+                }
+            }
+            let b: B satisfy {
+                f(a) = p and f(b) = q and relation_pushforward(g, r, a, b)
+            }
+            relation_pushforward_has_preimages(g, r, a, b)
+            let x: A satisfy {
+                exists(y: A) {
+                    g(x) = a and g(y) = b and r(x, y)
+                }
+            }
+            let y: A satisfy {
+                g(x) = a and g(y) = b and r(x, y)
+            }
+            compose(f, g, x) = f(g(x))
+            compose(f, g, y) = f(g(y))
+            compose(f, g)(x) = p
+            compose(f, g)(y) = q
+            f(g(x)) = p
+            f(g(y)) = q
+            exists(x0: A, y0: A) {
+                x0 = x and y0 = y and compose(f, g)(x0) = p and compose(f, g)(y0) = q and r(x0, y0)
+            }
+            relation_pushforward(compose(f, g), r, p, q)
+            u(p, q)
+        }
+        u(p, q) = v(p, q)
+    }
+    binary_function_extensionality(u, v)
+}
+
+/// Pushforward preserves reflexive relations along surjective functions.
+theorem relation_pushforward_is_reflexive_of_surjective[A, B](f: A -> B, r: (A, A) -> Bool) {
+    is_surjective_fn(f) and is_reflexive(r) implies is_reflexive(relation_pushforward(f, r))
+} by {
+    if is_surjective_fn(f) and is_reflexive(r) {
+        forall(u: B) {
+            surjective_fn_has_preimage(f, u)
+            let x: A satisfy {
+                f(x) = u
+            }
+            reflexive_self(r, x)
+            relation_pushforward_intro(f, r, x, x)
+            relation_pushforward(f, r, u, u)
+        }
+    }
+}
+
+/// Pushforward preserves symmetric relations.
+theorem relation_pushforward_is_symmetric[A, B](f: A -> B, r: (A, A) -> Bool) {
+    is_symmetric(r) implies is_symmetric(relation_pushforward(f, r))
+} by {
+    if is_symmetric(r) {
+        forall(u: B, v: B) {
+            if relation_pushforward(f, r, u, v) {
+                relation_pushforward_has_preimages(f, r, u, v)
+                let x: A satisfy {
+                    exists(y: A) {
+                        f(x) = u and f(y) = v and r(x, y)
+                    }
+                }
+                let y: A satisfy {
+                    f(x) = u and f(y) = v and r(x, y)
+                }
+                symmetric_flip(r, x, y)
+                r(y, x)
+                exists(a: A, b: A) {
+                    a = y and b = x and f(a) = v and f(b) = u and r(a, b)
+                }
+                relation_pushforward(f, r, v, u)
+            }
+        }
+    }
+}
+
+/// Pushforward preserves transitive relations along injective functions.
+theorem relation_pushforward_is_transitive_of_injective[A, B](f: A -> B, r: (A, A) -> Bool) {
+    is_injective_fn(f) and is_transitive(r) implies is_transitive(relation_pushforward(f, r))
+} by {
+    if is_injective_fn(f) and is_transitive(r) {
+        forall(u: B, v: B, w: B) {
+            if relation_pushforward(f, r, u, v) and relation_pushforward(f, r, v, w) {
+                relation_pushforward_has_preimages(f, r, u, v)
+                let x1: A satisfy {
+                    exists(y1: A) {
+                        f(x1) = u and f(y1) = v and r(x1, y1)
+                    }
+                }
+                let y1: A satisfy {
+                    f(x1) = u and f(y1) = v and r(x1, y1)
+                }
+                relation_pushforward_has_preimages(f, r, v, w)
+                let x2: A satisfy {
+                    exists(y2: A) {
+                        f(x2) = v and f(y2) = w and r(x2, y2)
+                    }
+                }
+                let y2: A satisfy {
+                    f(x2) = v and f(y2) = w and r(x2, y2)
+                }
+                f(y1) = f(x2)
+                injective_fn_eq(f, y1, x2)
+                y1 = x2
+                r(x1, x2)
+                transitive_step(r, x1, x2, y2)
+                r(x1, y2)
+                exists(a: A, b: A) {
+                    a = x1 and b = y2 and f(a) = u and f(b) = w and r(a, b)
+                }
+                relation_pushforward(f, r, u, w)
+            }
+        }
+    }
+}
+
+/// Pushforward preserves total relations along surjective functions.
+theorem relation_pushforward_is_total_of_surjective[A, B](f: A -> B, r: (A, A) -> Bool) {
+    is_surjective_fn(f) and is_total(r) implies is_total(relation_pushforward(f, r))
+} by {
+    if is_surjective_fn(f) and is_total(r) {
+        is_total(r) = forall(x0: A, y0: A) {
+            r(x0, y0) or r(y0, x0)
+        }
+        forall(u: B, v: B) {
+            surjective_fn_has_preimage(f, u)
+            let x: A satisfy {
+                f(x) = u
+            }
+            surjective_fn_has_preimage(f, v)
+            let y: A satisfy {
+                f(y) = v
+            }
+            r(x, y) or r(y, x)
+            if r(x, y) {
+                relation_pushforward_intro(f, r, x, y)
+                relation_pushforward(f, r, u, v)
+                relation_pushforward(f, r, u, v) or relation_pushforward(f, r, v, u)
+            } else {
+                relation_pushforward_intro(f, r, y, x)
+                relation_pushforward(f, r, v, u)
+                relation_pushforward(f, r, u, v) or relation_pushforward(f, r, v, u)
+            }
+        }
+    }
+}
+
+/// Pushforward preserves antisymmetric relations along injective functions.
+theorem relation_pushforward_is_antisymmetric_of_injective[A, B](f: A -> B, r: (A, A) -> Bool) {
+    is_injective_fn(f) and is_antisymmetric(r) implies is_antisymmetric(relation_pushforward(f, r))
+} by {
+    if is_injective_fn(f) and is_antisymmetric(r) {
+        forall(u: B, v: B) {
+            if relation_pushforward(f, r, u, v) and relation_pushforward(f, r, v, u) {
+                relation_pushforward_has_preimages(f, r, u, v)
+                let x1: A satisfy {
+                    exists(y1: A) {
+                        f(x1) = u and f(y1) = v and r(x1, y1)
+                    }
+                }
+                let y1: A satisfy {
+                    f(x1) = u and f(y1) = v and r(x1, y1)
+                }
+                relation_pushforward_has_preimages(f, r, v, u)
+                let x2: A satisfy {
+                    exists(y2: A) {
+                        f(x2) = v and f(y2) = u and r(x2, y2)
+                    }
+                }
+                let y2: A satisfy {
+                    f(x2) = v and f(y2) = u and r(x2, y2)
+                }
+                f(y1) = f(x2)
+                injective_fn_eq(f, y1, x2)
+                y1 = x2
+                f(x1) = f(y2)
+                injective_fn_eq(f, x1, y2)
+                x1 = y2
+                r(y1, x1)
+                antisymmetric_eq(r, x1, y1)
+                x1 = y1
+                f(x1) = f(y1)
+                u = v
+            }
+        }
+    }
+}
+
+/// Pushforward preserves equivalence relations along bijective functions.
+theorem relation_pushforward_is_equivalence_of_bijection[A, B](f: A -> B, r: (A, A) -> Bool) {
+    is_bijection_fn(f) and is_equivalence(r) implies is_equivalence(relation_pushforward(f, r))
+} by {
+    if is_bijection_fn(f) and is_equivalence(r) {
+        bijection_fn_is_surjective(f)
+        is_surjective_fn(f)
+        equivalence_is_reflexive(r)
+        is_reflexive(r)
+        relation_pushforward_is_reflexive_of_surjective(f, r)
+        is_reflexive(relation_pushforward(f, r))
+        equivalence_is_symmetric(r)
+        is_symmetric(r)
+        relation_pushforward_is_symmetric(f, r)
+        is_symmetric(relation_pushforward(f, r))
+        bijection_fn_is_injective(f)
+        is_injective_fn(f)
+        equivalence_is_transitive(r)
+        is_transitive(r)
+        relation_pushforward_is_transitive_of_injective(f, r)
+        is_transitive(relation_pushforward(f, r))
+        is_equivalence(relation_pushforward(f, r))
+    }
+}
+
+/// Pushforward preserves reflexive, transitive, and antisymmetric order data along bijective functions.
+theorem relation_pushforward_is_reflexive_transitive_antisymmetric_of_bijection[A, B](f: A -> B, r: (A, A) -> Bool) {
+    is_bijection_fn(f) and is_reflexive(r) and is_transitive(r) and is_antisymmetric(r) implies
+    is_reflexive(relation_pushforward(f, r)) and
+    is_transitive(relation_pushforward(f, r)) and
+    is_antisymmetric(relation_pushforward(f, r))
+} by {
+    if is_bijection_fn(f) and is_reflexive(r) and is_transitive(r) and is_antisymmetric(r) {
+        bijection_fn_is_surjective(f)
+        is_surjective_fn(f)
+        relation_pushforward_is_reflexive_of_surjective(f, r)
+        is_reflexive(relation_pushforward(f, r))
+        bijection_fn_is_injective(f)
+        is_injective_fn(f)
+        relation_pushforward_is_transitive_of_injective(f, r)
+        is_transitive(relation_pushforward(f, r))
+        relation_pushforward_is_antisymmetric_of_injective(f, r)
+        is_antisymmetric(relation_pushforward(f, r))
+        is_reflexive(relation_pushforward(f, r)) and
+        is_transitive(relation_pushforward(f, r)) and
+        is_antisymmetric(relation_pushforward(f, r))
+    }
+}
+
+/// Pullback after pushforward contains the original relation.
+theorem relation_subset_pullback_pushforward[A, B](f: A -> B, r: (A, A) -> Bool) {
+    relation_subset(r, relation_pullback(f, relation_pushforward(f, r)))
+} by {
+    forall(x: A, y: A) {
+        if r(x, y) {
+            relation_pushforward_intro(f, r, x, y)
+            relation_pullback(f, relation_pushforward(f, r), x, y)
+        }
+    }
+}
+
+/// Pullback after pushforward recovers each original relation instance along injective functions.
+theorem relation_pullback_pushforward_of_injective_at[A, B](f: A -> B, r: (A, A) -> Bool, x: A, y: A) {
+    is_injective_fn(f) implies relation_pullback(f, relation_pushforward(f, r), x, y) = r(x, y)
+} by {
+    if is_injective_fn(f) {
+        if relation_pullback(f, relation_pushforward(f, r), x, y) {
+            relation_pullback(f, relation_pushforward(f, r), x, y) =
+                relation_pushforward(f, r, f(x), f(y))
+            relation_pushforward_has_preimages(f, r, f(x), f(y))
+            let a: A satisfy {
+                exists(b: A) {
+                    f(a) = f(x) and f(b) = f(y) and r(a, b)
+                }
+            }
+            let b: A satisfy {
+                f(a) = f(x) and f(b) = f(y) and r(a, b)
+            }
+            injective_fn_eq(f, a, x)
+            a = x
+            injective_fn_eq(f, b, y)
+            b = y
+            r(x, y)
+        }
+        if r(x, y) {
+            relation_subset_pullback_pushforward(f, r)
+            relation_pullback(f, relation_pushforward(f, r), x, y)
+        }
+        relation_pullback(f, relation_pushforward(f, r), x, y) = r(x, y)
+    }
+}
+
+/// Pullback after pushforward recovers the original relation along injective functions.
+theorem relation_pullback_pushforward_of_injective[A, B](f: A -> B, r: (A, A) -> Bool) {
+    is_injective_fn(f) implies relation_pullback(f, relation_pushforward(f, r)) = r
+} by {
+    let u = relation_pullback(f, relation_pushforward(f, r))
+    let v = r
+    if is_injective_fn(f) {
+        forall(x: A, y: A) {
+            relation_pullback_pushforward_of_injective_at(f, r, x, y)
+            u(x, y) = v(x, y)
+        }
+        binary_function_extensionality(u, v)
+    }
+}
+
+/// Pushforward after pullback is contained in the target relation.
+theorem relation_subset_pushforward_pullback[A, B](f: A -> B, r: (B, B) -> Bool) {
+    relation_subset(relation_pushforward(f, relation_pullback(f, r)), r)
+} by {
+    forall(u: B, v: B) {
+        if relation_pushforward(f, relation_pullback(f, r), u, v) {
+            relation_pushforward_has_preimages(f, relation_pullback(f, r), u, v)
+            let x: A satisfy {
+                exists(y: A) {
+                    f(x) = u and f(y) = v and relation_pullback(f, r, x, y)
+                }
+            }
+            let y: A satisfy {
+                f(x) = u and f(y) = v and relation_pullback(f, r, x, y)
+            }
+            relation_pullback(f, r, x, y) = r(f(x), f(y))
+            r(f(x), f(y))
+            r(u, v)
+        }
+    }
+}
+
+/// Pushforward after pullback recovers each target relation instance along surjective functions.
+theorem relation_pushforward_pullback_of_surjective_at[A, B](f: A -> B, r: (B, B) -> Bool, p: B, q: B) {
+    is_surjective_fn(f) implies relation_pushforward(f, relation_pullback(f, r), p, q) = r(p, q)
+} by {
+    if is_surjective_fn(f) {
+        if relation_pushforward(f, relation_pullback(f, r), p, q) {
+            relation_subset_pushforward_pullback(f, r)
+            r(p, q)
+        }
+        if r(p, q) {
+            surjective_fn_has_preimage(f, p)
+            let x: A satisfy {
+                f(x) = p
+            }
+            surjective_fn_has_preimage(f, q)
+            let y: A satisfy {
+                f(y) = q
+            }
+            relation_pullback(f, r, x, y) = r(f(x), f(y))
+            relation_pullback(f, r, x, y)
+            exists(a: A, b: A) {
+                a = x and b = y and f(a) = p and f(b) = q and relation_pullback(f, r, a, b)
+            }
+            relation_pushforward(f, relation_pullback(f, r), p, q)
+        }
+        relation_pushforward(f, relation_pullback(f, r), p, q) = r(p, q)
+    }
+}
+
+/// Pushforward after pullback recovers the target relation along surjective functions.
+theorem relation_pushforward_pullback_of_surjective[A, B](f: A -> B, r: (B, B) -> Bool) {
+    is_surjective_fn(f) implies relation_pushforward(f, relation_pullback(f, r)) = r
+} by {
+    let u = relation_pushforward(f, relation_pullback(f, r))
+    let v = r
+    if is_surjective_fn(f) {
+        forall(p: B, q: B) {
+            relation_pushforward_pullback_of_surjective_at(f, r, p, q)
+            u(p, q) = v(p, q)
+        }
+        binary_function_extensionality(u, v)
+    }
+}
+
 /// Pullback commutes with converse.
 theorem relation_pullback_converse[A, B](f: A -> B, r: (B, B) -> Bool) {
     relation_pullback(f, relation_converse(r)) = relation_converse(relation_pullback(f, r))


### PR DESCRIPTION
## Summary
- add `relation_pushforward` for images of homogeneous relations along functions
- prove monotonicity, identity, composition, preservation of reflexive/symmetric/transitive/total/antisymmetric/equivalence/order-like relation data
- add pullback/pushforward round-trip containment and recovery lemmas under injective or surjective maps
- narrow the translate-mathlib transport roadmap toward predicate/function transport as the next frontier

## Verification
- `acorn check` (17609/17609 OK)

Stacked on #194 (`translate-mathlib-chunk-20260429-173236`).
