### PR TITLE
feat: add predicate transport lemmas

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -77,7 +77,7 @@
     "real.triangular_sum": "233d44e2ede6c7b2278d8c071b84b79bf98cef0d4a608cd3e0df47d175121cfb",
     "relation": "be09d2c2e6cc9476149617d306955e6ff8c834c86eb8082b81b7a11d9a74fb2d",
     "relation_basic": "4b81bfe420a92c4d21073062e633b61db1572448ac1935a11ce8d66dbe078b80",
-    "relation_transport": "68c37ddce95026bb77bd9efb56eaec3bc92912d7ce6476cae28fe14ee6cea69a",
+    "relation_transport": "a37627b0fcb86e0a06dbdaf230f906e5b4cfc08b4fb41656f8851e1375fec2ed",
     "ring": "ca879591091e736df94f2fea9ad637a5a3b5f53fc9331105469a347d9727da4c",
     "semigroup": "fe447410f73ecf26812d523903d89bd4e8fc9f57abf4b6326c1d96b97efd0935",
     "semiring": "a9e2a52a901c480363ff641631c280bdbbf6fe964eda9fb83b22cd0d4eb5fcb5",

--- a/build/relation_transport.jsonl
+++ b/build/relation_transport.jsonl
@@ -1,3 +1,148 @@
+{"goal":"predicate_subset[T](p, q) = forall(x0: T) { p(x0) implies q(x0) }","proof":["function[T0](x0: T0 -> Bool, x1: T0 -> Bool) { forall(x2: T0) { not x0(x2) or x1(x2) } = predicate_subset[T0](x0, x1) }[T](p, q)"]}
+{"goal":"q(x)","proof":["p(x)","predicate_subset[T](p, q)","(forall(x0: T) { not p(x0) or q(x0) } = true)","function(x0: T) { not (p(x0) and not q(x0)) }(x)"]}
+{"goal":"predicate_subset_step","proof":[]}
+{"goal":"p(x)","proof":[]}
+{"goal":"predicate_subset_refl","proof":["function[T0](x0: T0 -> Bool, x1: T0 -> Bool) { forall(x2: T0) { not x0(x2) or x1(x2) } = predicate_subset[T0](x0, x1) }[T](p, p)","not forall(x0: T) { not p(x0) or p(x0) }","let w0: T satisfy { p(w0) and not p(w0) }"]}
+{"goal":"q(x)","proof":[]}
+{"goal":"r(x)","proof":[]}
+{"goal":"predicate_subset_trans","proof":["function[T0](x0: T0 -> Bool, x1: T0 -> Bool) { forall(x2: T0) { not x0(x2) or x1(x2) } = predicate_subset[T0](x0, x1) }[T](p, r)"]}
+{"goal":"predicate_subset[T](p, q)","proof":[]}
+{"goal":"predicate_subset[T](q, p)","proof":[]}
+{"goal":"predicate_subset[T](p, q) and predicate_subset[T](q, p)","proof":[]}
+{"goal":"q(x)","proof":[]}
+{"goal":"p(x)","proof":[]}
+{"goal":"p(x) = q(x)","proof":[]}
+{"goal":"p = q","proof":[]}
+{"goal":"p = q = (predicate_subset[T](p, q) and predicate_subset[T](q, p))","proof":[]}
+{"goal":"predicate_eq_iff_subset_both","proof":[]}
+{"goal":"exists(k0: A) { k0 = x and f(k0) = f(x) and p(k0) }","proof":[]}
+{"goal":"predicate_pushforward[A, B](f, p, f(x))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T0 -> Bool) { exists(k0: T0) { x0(k0) = x1 and x2(k0) } = predicate_pushforward[T0, T1](x0, x2, x1) }[A, B](f, f(x), p)"]}
+{"goal":"predicate_pushforward_intro","proof":[]}
+{"goal":"exists(k0: A) { f(k0) = y and p(k0) }","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T0 -> Bool) { exists(k0: T0) { x0(k0) = x1 and x2(k0) } = predicate_pushforward[T0, T1](x0, x2, x1) }[A, B](f, y, p)"]}
+{"goal":"predicate_pushforward_has_preimage","proof":[]}
+{"goal":"u(x) = p(identity_fn(x))","proof":["function(x0: T) { predicate_pullback(identity_fn[T], p, x0) = u(x0) }(x)","function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[T, T](identity_fn[T], p, x)"]}
+{"goal":"identity_fn(x) = x","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](x)"]}
+{"goal":"u(x) = p(x)","proof":[]}
+{"goal":"predicate_pullback_identity","proof":[]}
+{"goal":"exists(k0: T) { identity_fn(k0) = x and p(k0) }","proof":[]}
+{"goal":"identity_fn(a) = a","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](a)"]}
+{"goal":"a = x","proof":[]}
+{"goal":"p(x)","proof":[]}
+{"goal":"identity_fn(x) = x","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](x)"]}
+{"goal":"u(x)","proof":[]}
+{"goal":"u(x) = p(x)","proof":[]}
+{"goal":"predicate_pushforward_identity","proof":[]}
+{"goal":"u(x) = p(compose[A, B, C](f, g)(x))","proof":["function(x0: A) { predicate_pullback[A, C](compose[A, B, C](f, g), p, x0) = u(x0) }(x)","function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, C](compose[A, B, C](f, g), p, x)"]}
+{"goal":"compose[A, B, C](f, g, x) = f(g(x))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](f, g, x)"]}
+{"goal":"v(x) = predicate_pullback[B, C](f, p, g(x))","proof":["function(x0: A) { predicate_pullback[A, B](g, predicate_pullback[B, C](f, p), x0) = v(x0) }(x)","function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, B](g, predicate_pullback[B, C](f, p), x)"]}
+{"goal":"predicate_pullback[B, C](f, p, g(x)) = p(f(g(x)))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[B, C](f, p, g(x))"]}
+{"goal":"u(x) = v(x)","proof":[]}
+{"goal":"predicate_pullback_compose","proof":[]}
+{"goal":"exists(k0: A) { compose[A, B, C](f, g)(k0) = z and p(k0) }","proof":[]}
+{"goal":"compose[A, B, C](f, g, x) = f(g(x))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](f, g, x)"]}
+{"goal":"predicate_pushforward[A, B](g, p, g(x))","proof":[]}
+{"goal":"exists(k0: B) { k0 = g(x) and f(k0) = z and predicate_pushforward[A, B](g, p, k0) }","proof":[]}
+{"goal":"predicate_pushforward[B, C](f, predicate_pushforward[A, B](g, p), z)","proof":["let w0: B satisfy { g(x) = w0 and f(w0) = z and predicate_pushforward[A, B](g, p, w0) }","function[T0, T1](x0: T0 -> T1, x1: T1, x2: T0 -> Bool) { exists(k0: T0) { x0(k0) = x1 and x2(k0) } = predicate_pushforward[T0, T1](x0, x2, x1) }[B, C](f, z, predicate_pushforward[A, B](g, p))","predicate_pushforward[A, B](g, p, w0)","not exists(k0: B) { f(k0) = z and predicate_pushforward[A, B](g, p, k0) }","g(x) = w0 and f(w0) = z","function(x0: B) { not (f(x0) = z and predicate_pushforward[A, B](g, p, x0)) }(w0)"]}
+{"goal":"v(z)","proof":[]}
+{"goal":"exists(k0: B) { f(k0) = z and predicate_pushforward[A, B](g, p, k0) }","proof":[]}
+{"goal":"exists(k0: A) { g(k0) = y and p(k0) }","proof":[]}
+{"goal":"compose[A, B, C](f, g, x) = f(g(x))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](f, g, x)"]}
+{"goal":"compose[A, B, C](f, g)(x) = z","proof":[]}
+{"goal":"exists(k0: A) { k0 = x and compose[A, B, C](f, g)(k0) = z and p(k0) }","proof":[]}
+{"goal":"predicate_pushforward[A, C](compose[A, B, C](f, g), p, z)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T0 -> Bool) { exists(k0: T0) { x0(k0) = x1 and x2(k0) } = predicate_pushforward[T0, T1](x0, x2, x1) }[A, C](compose[A, B, C](f, g), z, p)","p(x)","not exists(k0: A) { compose[A, B, C](f, g, k0) = z and p(k0) }","function(x0: A) { not (compose[A, B, C](f, g, x0) = z and p(x0)) }(x)"]}
+{"goal":"u(z)","proof":[]}
+{"goal":"u(z) = v(z)","proof":[]}
+{"goal":"predicate_pushforward_compose","proof":[]}
+{"goal":"predicate_pullback[A, B](f, p, x) = p(f(x))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, B](f, p, x)"]}
+{"goal":"p(f(x))","proof":[]}
+{"goal":"q(f(x))","proof":[]}
+{"goal":"predicate_pullback[A, B](f, q, x)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, B](f, q, x)"]}
+{"goal":"predicate_pullback_monotone","proof":["function[T0](x0: T0 -> Bool, x1: T0 -> Bool) { forall(x2: T0) { not x0(x2) or x1(x2) } = predicate_subset[T0](x0, x1) }[A](predicate_pullback[A, B](f, p), predicate_pullback[A, B](f, q))"]}
+{"goal":"exists(k0: A) { f(k0) = y and p(k0) }","proof":[]}
+{"goal":"q(x)","proof":[]}
+{"goal":"exists(k0: A) { k0 = x and f(k0) = y and q(k0) }","proof":[]}
+{"goal":"predicate_pushforward[A, B](f, q, y)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T0 -> Bool) { exists(k0: T0) { x0(k0) = x1 and x2(k0) } = predicate_pushforward[T0, T1](x0, x2, x1) }[A, B](f, y, q)","f(x) = y","not exists(k0: A) { f(k0) = y and q(k0) }","function(x0: A) { not (f(x0) = y and q(x0)) }(x)"]}
+{"goal":"predicate_pushforward_monotone","proof":["function[T0](x0: T0 -> Bool, x1: T0 -> Bool) { forall(x2: T0) { not x0(x2) or x1(x2) } = predicate_subset[T0](x0, x1) }[B](predicate_pushforward[A, B](f, p), predicate_pushforward[A, B](f, q))"]}
+{"goal":"predicate_pushforward[A, B](f, p, f(x))","proof":[]}
+{"goal":"predicate_pullback[A, B](f, predicate_pushforward[A, B](f, p), x)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, B](f, predicate_pushforward[A, B](f, p), x)"]}
+{"goal":"predicate_subset_pullback_pushforward","proof":["function[T0](x0: T0 -> Bool, x1: T0 -> Bool) { forall(x2: T0) { not x0(x2) or x1(x2) } = predicate_subset[T0](x0, x1) }[A](p, predicate_pullback[A, B](f, predicate_pushforward[A, B](f, p)))","let w0: A satisfy { p(w0) and not predicate_pullback[A, B](f, predicate_pushforward[A, B](f, p), w0) }","function(x0: A) { not p(x0) or predicate_pullback[A, B](f, predicate_pushforward[A, B](f, p), x0) }(w0)"]}
+{"goal":"predicate_pullback[A, B](f, predicate_pushforward[A, B](f, p), x) = predicate_pushforward[A, B](f, p, f(x))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, B](f, predicate_pushforward[A, B](f, p), x)"]}
+{"goal":"exists(k0: A) { f(k0) = f(x) and p(k0) }","proof":[]}
+{"goal":"a = x","proof":[]}
+{"goal":"p(x)","proof":[]}
+{"goal":"predicate_pullback[A, B](f, predicate_pushforward[A, B](f, p), x)","proof":["function[T0, T3](x0: T0 -> Bool, x1: T0, x2: T0 -> T3) { not x0(x1) or predicate_pushforward[T0, T3](x2, x0, x2(x1)) }[A, B](p, x, f)","function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, B](f, predicate_pushforward[A, B](f, p), x)"]}
+{"goal":"predicate_pullback[A, B](f, predicate_pushforward[A, B](f, p), x) = p(x)","proof":[]}
+{"goal":"predicate_pullback_pushforward_of_injective_at","proof":[]}
+{"goal":"u(x) = p(x)","proof":[]}
+{"goal":"predicate_pullback_pushforward_of_injective","proof":["let w0: A satisfy { p(w0) != predicate_pullback[A, B](f, predicate_pushforward[A, B](f, p), w0) }","function[T0, T1](x0: T0 -> T1, x1: T0 -> Bool, x2: T0) { not is_injective_fn[T0, T1](x0) or predicate_pullback[T0, T1](x0, predicate_pushforward[T0, T1](x0, x1), x2) = x1(x2) }[A, B](f, p, w0)"]}
+{"goal":"exists(k0: A) { f(k0) = y and predicate_pullback[A, B](f, p, k0) }","proof":[]}
+{"goal":"predicate_pullback[A, B](f, p, x) = p(f(x))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, B](f, p, x)"]}
+{"goal":"p(f(x))","proof":[]}
+{"goal":"p(y)","proof":[]}
+{"goal":"predicate_subset_pushforward_pullback","proof":["function[T0](x0: T0 -> Bool, x1: T0 -> Bool) { forall(x2: T0) { not x0(x2) or x1(x2) } = predicate_subset[T0](x0, x1) }[B](predicate_pushforward[A, B](f, predicate_pullback[A, B](f, p)), p)","let w0: B satisfy { predicate_pushforward[A, B](f, predicate_pullback[A, B](f, p), w0) and not p(w0) }","function(x0: B) { not predicate_pushforward[A, B](f, predicate_pullback[A, B](f, p), x0) or p(x0) }(w0)"]}
+{"goal":"p(y)","proof":["function[T0](x0: T0 -> Bool, x1: T0 -> Bool, x2: T0) { not predicate_subset[T0](x0, x1) or not x0(x2) or x1(x2) }[B](predicate_pushforward[A, B](f, predicate_pullback[A, B](f, p)), p, y)"]}
+{"goal":"exists(k0: A) { f(k0) = y }","proof":[]}
+{"goal":"predicate_pullback[A, B](f, p, x) = p(f(x))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, B](f, p, x)"]}
+{"goal":"predicate_pullback[A, B](f, p, x)","proof":[]}
+{"goal":"exists(k0: A) { k0 = x and f(k0) = y and predicate_pullback[A, B](f, p, k0) }","proof":[]}
+{"goal":"predicate_pushforward[A, B](f, predicate_pullback[A, B](f, p), y)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T0 -> Bool) { exists(k0: T0) { x0(k0) = x1 and x2(k0) } = predicate_pushforward[T0, T1](x0, x2, x1) }[A, B](f, y, predicate_pullback[A, B](f, p))","not exists(k0: A) { f(k0) = y and predicate_pullback[A, B](f, p, k0) }","function(x0: A) { not (f(x0) = y and predicate_pullback[A, B](f, p, x0)) }(x)"]}
+{"goal":"predicate_pushforward[A, B](f, predicate_pullback[A, B](f, p), y) = p(y)","proof":[]}
+{"goal":"predicate_pushforward_pullback_of_surjective_at","proof":[]}
+{"goal":"u(y) = p(y)","proof":[]}
+{"goal":"predicate_pushforward_pullback_of_surjective","proof":["let w0: B satisfy { p(w0) != predicate_pushforward[A, B](f, predicate_pullback[A, B](f, p), w0) }","function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T1) { not is_surjective_fn[T0, T1](x0) or predicate_pushforward[T0, T1](x0, predicate_pullback[T0, T1](x0, x1), x2) = x1(x2) }[A, B](f, p, w0)"]}
+{"goal":"predicate_pullback[A, B](f, predicate_pushforward[A, B](f, p)) = p","proof":[]}
+{"goal":"predicate_pullback_pushforward_of_bijection","proof":[]}
+{"goal":"predicate_pushforward[A, B](f, predicate_pullback[A, B](f, p)) = p","proof":[]}
+{"goal":"predicate_pushforward_pullback_of_bijection","proof":[]}
+{"goal":"exists(k0: A) { f(k0) = y }","proof":[]}
+{"goal":"predicate_pullback[A, B](f, p, x) = p(f(x))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, B](f, p, x)"]}
+{"goal":"predicate_pullback[A, B](f, p, x)","proof":[]}
+{"goal":"predicate_pullback[A, B](f, q, x)","proof":[]}
+{"goal":"predicate_pullback[A, B](f, q, x) = q(f(x))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[A, B](f, q, x)"]}
+{"goal":"q(y)","proof":[]}
+{"goal":"predicate_pullback_subset_imp_subset_of_surjective","proof":["function[T0](x0: T0 -> Bool, x1: T0 -> Bool) { forall(x2: T0) { not x0(x2) or x1(x2) } = predicate_subset[T0](x0, x1) }[B](p, q)"]}
+{"goal":"predicate_subset[B](p, q)","proof":[]}
+{"goal":"predicate_subset[A](predicate_pullback[A, B](f, p), predicate_pullback[A, B](f, q))","proof":[]}
+{"goal":"predicate_subset[A](predicate_pullback[A, B](f, p), predicate_pullback[A, B](f, q)) = predicate_subset[B](p, q)","proof":[]}
+{"goal":"predicate_pullback_subset_iff_of_surjective","proof":[]}
+{"goal":"predicate_subset[A](predicate_pullback[A, B](f, p), predicate_pullback[A, B](f, q))","proof":[]}
+{"goal":"predicate_subset[A](predicate_pullback[A, B](f, q), predicate_pullback[A, B](f, p))","proof":[]}
+{"goal":"predicate_subset[B](p, q)","proof":[]}
+{"goal":"predicate_subset[B](q, p)","proof":[]}
+{"goal":"p = q","proof":[]}
+{"goal":"predicate_pullback_eq_imp_eq_of_surjective","proof":[]}
+{"goal":"p = q","proof":[]}
+{"goal":"predicate_pullback[A, B](f, p) = predicate_pullback[A, B](f, q)","proof":[]}
+{"goal":"predicate_pullback[A, B](f, p) = predicate_pullback[A, B](f, q) = (p = q)","proof":[]}
+{"goal":"predicate_pullback_eq_iff_of_surjective","proof":[]}
+{"goal":"predicate_pushforward[A, B](f, p, f(x))","proof":[]}
+{"goal":"predicate_pushforward[A, B](f, q, f(x))","proof":[]}
+{"goal":"exists(k0: A) { f(k0) = f(x) and q(k0) }","proof":[]}
+{"goal":"a = x","proof":[]}
+{"goal":"q(x)","proof":[]}
+{"goal":"predicate_pushforward_subset_imp_subset_of_injective","proof":["function[T0](x0: T0 -> Bool, x1: T0 -> Bool) { forall(x2: T0) { not x0(x2) or x1(x2) } = predicate_subset[T0](x0, x1) }[A](p, q)"]}
+{"goal":"predicate_subset[A](p, q)","proof":[]}
+{"goal":"predicate_subset[B](predicate_pushforward[A, B](f, p), predicate_pushforward[A, B](f, q))","proof":[]}
+{"goal":"predicate_subset[B](predicate_pushforward[A, B](f, p), predicate_pushforward[A, B](f, q)) = predicate_subset[A](p, q)","proof":[]}
+{"goal":"predicate_pushforward_subset_iff_of_injective","proof":[]}
+{"goal":"predicate_subset[B](predicate_pushforward[A, B](f, p), predicate_pushforward[A, B](f, q))","proof":[]}
+{"goal":"predicate_subset[B](predicate_pushforward[A, B](f, q), predicate_pushforward[A, B](f, p))","proof":[]}
+{"goal":"predicate_subset[A](p, q)","proof":[]}
+{"goal":"predicate_subset[A](q, p)","proof":[]}
+{"goal":"p = q","proof":[]}
+{"goal":"predicate_pushforward_eq_imp_eq_of_injective","proof":[]}
+{"goal":"p = q","proof":[]}
+{"goal":"predicate_pushforward[A, B](f, p) = predicate_pushforward[A, B](f, q)","proof":[]}
+{"goal":"predicate_pushforward[A, B](f, p) = predicate_pushforward[A, B](f, q) = (p = q)","proof":[]}
+{"goal":"predicate_pushforward_eq_iff_of_injective","proof":[]}
+{"goal":"predicate_subset[A](predicate_pullback[A, B](f, p), predicate_pullback[A, B](f, q)) = predicate_subset[B](p, q)","proof":[]}
+{"goal":"predicate_pullback_subset_iff_of_bijection","proof":[]}
+{"goal":"predicate_subset[B](predicate_pushforward[A, B](f, p), predicate_pushforward[A, B](f, q)) = predicate_subset[A](p, q)","proof":[]}
+{"goal":"predicate_pushforward_subset_iff_of_bijection","proof":[]}
+{"goal":"predicate_pullback[A, B](f, p) = predicate_pullback[A, B](f, q) = (p = q)","proof":[]}
+{"goal":"predicate_pullback_eq_iff_of_bijection","proof":[]}
+{"goal":"predicate_pushforward[A, B](f, p) = predicate_pushforward[A, B](f, q) = (p = q)","proof":[]}
+{"goal":"predicate_pushforward_eq_iff_of_bijection","proof":[]}
 {"goal":"exists(k0: A, k1: A) { k0 = x and k1 = y and f(k0) = f(x) and f(k1) = f(y) and r(k0, k1) }","proof":[]}
 {"goal":"relation_pushforward[A, B](f, r, f(x), f(y))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T1, x3: (T0, T0) -> Bool) { exists(k0: T0, k1: T0) { x0(k0) = x1 and x0(k1) = x2 and x3(k0, k1) } = relation_pushforward[T0, T1](x0, x3, x1, x2) }[A, B](f, f(x), f(y), r)"]}
 {"goal":"relation_pushforward_intro","proof":[]}
@@ -103,8 +248,8 @@
 {"goal":"is_injective_fn[A, B](f)","proof":[]}
 {"goal":"is_transitive[B](relation_pushforward[A, B](f, r))","proof":[]}
 {"goal":"is_antisymmetric[B](relation_pushforward[A, B](f, r))","proof":[]}
-{"goal":"is_reflexive[B](relation_pushforward[A, B](f, r)) and is_transitive[B](relation_pushforward[A, B](f, r)) and is_antisymmetric[B](relation_pushforward[A, B](f, r))","proof":["not is_reflexive[B](relation_pushforward[A, B](f, r))"]}
-{"goal":"relation_pushforward_is_reflexive_transitive_antisymmetric_of_bijection","proof":["is_antisymmetric[A](r)","is_bijection_fn[A, B](f) and is_reflexive[A](r) and is_transitive[A](r)","is_reflexive[A](r)","is_bijection_fn[A, B](f)","is_reflexive[B](relation_pushforward[A, B](f, r)) and is_transitive[B](relation_pushforward[A, B](f, r)) and is_antisymmetric[B](relation_pushforward[A, B](f, r))","not is_transitive[B](relation_pushforward[A, B](f, r)) or not is_reflexive[B](relation_pushforward[A, B](f, r))","is_transitive[B](relation_pushforward[A, B](f, r))","is_reflexive[B](relation_pushforward[A, B](f, r))","not is_reflexive[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"is_reflexive[B](relation_pushforward[A, B](f, r)) and is_transitive[B](relation_pushforward[A, B](f, r)) and is_antisymmetric[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"relation_pushforward_is_reflexive_transitive_antisymmetric_of_bijection","proof":[]}
 {"goal":"relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y)","proof":["function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, relation_pushforward[A, B](f, r), x, y)"]}
 {"goal":"relation_subset_pullback_pushforward","proof":["function[T0, T1](x0: (T0, T1) -> Bool, x1: (T0, T1) -> Bool) { forall(x2: T0, x3: T1) { not x0(x2, x3) or x1(x2, x3) } = relation_subset[T0, T1](x0, x1) }[A, A](r, relation_pullback[A, B](f, relation_pushforward[A, B](f, r)))","let w0: A satisfy { exists(k0: A) { r(w0, k0) and not relation_pullback[A, B](f, relation_pushforward[A, B](f, r), w0, k0) } }","let w1: A satisfy { r(w0, w1) and not relation_pullback[A, B](f, relation_pushforward[A, B](f, r), w0, w1) }","function(x0: A, x1: A) { not r(x0, x1) or relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x0, x1) }(w0, w1)"]}
 {"goal":"relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y) = relation_pushforward[A, B](f, r, f(x), f(y))","proof":["function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, relation_pushforward[A, B](f, r), x, y)"]}
@@ -114,8 +259,8 @@
 {"goal":"b = y","proof":[]}
 {"goal":"r(x, y)","proof":[]}
 {"goal":"relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y)","proof":["function[T0, T4](x0: (T0, T0) -> Bool, x1: T0, x2: T0, x3: T0 -> T4) { not x0(x1, x2) or relation_pushforward[T0, T4](x3, x0, x3(x1), x3(x2)) }[A, B](r, x, y, f)","function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, relation_pushforward[A, B](f, r), x, y)"]}
-{"goal":"relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y) = r(x, y)","proof":["relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y) or r(x, y)","r(x, y)","relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y)","not relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y)"]}
-{"goal":"relation_pullback_pushforward_of_injective_at","proof":["not is_injective_fn[A, B](f)"]}
+{"goal":"relation_pullback[A, B](f, relation_pushforward[A, B](f, r), x, y) = r(x, y)","proof":[]}
+{"goal":"relation_pullback_pushforward_of_injective_at","proof":[]}
 {"goal":"u(x, y) = r(x, y)","proof":[]}
 {"goal":"relation_pullback_pushforward_of_injective","proof":["let w0: A satisfy { r(w0) != relation_pullback[A, B](f, relation_pushforward[A, B](f, r), w0) }","let w1: A satisfy { r(w0, w1) != relation_pullback[A, B](f, relation_pushforward[A, B](f, r), w0, w1) }","function[T0, T1](x0: T0 -> T1, x1: (T0, T0) -> Bool, x2: T0, x3: T0) { not is_injective_fn[T0, T1](x0) or relation_pullback[T0, T1](x0, relation_pushforward[T0, T1](x0, x1), x2, x3) = x1(x2, x3) }[A, B](f, r, w0, w1)"]}
 {"goal":"exists(k0: A) { exists(k1: A) { f(k0) = u and f(k1) = v and relation_pullback[A, B](f, r, k0, k1) } }","proof":[]}
@@ -124,15 +269,15 @@
 {"goal":"r(f(x), f(y))","proof":[]}
 {"goal":"r(u, v)","proof":[]}
 {"goal":"relation_subset_pushforward_pullback","proof":["function[T0, T1](x0: (T0, T1) -> Bool, x1: (T0, T1) -> Bool) { forall(x2: T0, x3: T1) { not x0(x2, x3) or x1(x2, x3) } = relation_subset[T0, T1](x0, x1) }[B, B](relation_pushforward[A, B](f, relation_pullback[A, B](f, r)), r)","let w0: B satisfy { exists(k0: B) { relation_pushforward[A, B](f, relation_pullback[A, B](f, r), w0, k0) and not r(w0, k0) } }","let w1: B satisfy { relation_pushforward[A, B](f, relation_pullback[A, B](f, r), w0, w1) and not r(w0, w1) }","function(x0: B, x1: B) { not relation_pushforward[A, B](f, relation_pullback[A, B](f, r), x0, x1) or r(x0, x1) }(w0, w1)"]}
-{"goal":"r(p, q)","proof":["function[T0, T1](x0: (T0, T1) -> Bool, x1: (T0, T1) -> Bool, x2: T0, x3: T1) { not relation_subset[T0, T1](x0, x1) or not x0(x2, x3) or x1(x2, x3) }[B, B](relation_pushforward[A, B](f, relation_pullback[A, B](f, r)), r, p, q)","function(x0: (B, B) -> Bool) { not relation_subset[B, B](x0, r) or not x0(p, q) }(relation_pushforward[A, B](f, relation_pullback[A, B](f, r)))"]}
+{"goal":"r(p, q)","proof":["function[T0, T1](x0: (T0, T1) -> Bool, x1: (T0, T1) -> Bool, x2: T0, x3: T1) { not relation_subset[T0, T1](x0, x1) or not x0(x2, x3) or x1(x2, x3) }[B, B](relation_pushforward[A, B](f, relation_pullback[A, B](f, r)), r, p, q)"]}
 {"goal":"exists(k0: A) { f(k0) = p }","proof":[]}
 {"goal":"exists(k0: A) { f(k0) = q }","proof":[]}
 {"goal":"relation_pullback[A, B](f, r, x, y) = r(f(x), f(y))","proof":["function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, r, x, y)"]}
 {"goal":"relation_pullback[A, B](f, r, x, y)","proof":[]}
 {"goal":"exists(k0: A, k1: A) { k0 = x and k1 = y and f(k0) = p and f(k1) = q and relation_pullback[A, B](f, r, k0, k1) }","proof":[]}
 {"goal":"relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q)","proof":["function[T0, T1](x0: T0 -> T1, x1: T1, x2: T1, x3: (T0, T0) -> Bool) { exists(k0: T0, k1: T0) { x0(k0) = x1 and x0(k1) = x2 and x3(k0, k1) } = relation_pushforward[T0, T1](x0, x3, x1, x2) }[A, B](f, p, q, relation_pullback[A, B](f, r))","not exists(k0: A, k1: A) { f(k0) = p and f(k1) = q and relation_pullback[A, B](f, r, k0, k1) }","function(x0: A) { not exists(k0: A) { f(x0) = p and f(k0) = q and relation_pullback[A, B](f, r, x0, k0) } }(x)","function(x0: A, x1: A) { not (f(x0) = p and f(x1) = q and relation_pullback[A, B](f, r, x0, x1)) }(x, y)"]}
-{"goal":"relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q) = r(p, q)","proof":["relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q) or r(p, q)","r(p, q)","relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q)","not relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q)"]}
-{"goal":"relation_pushforward_pullback_of_surjective_at","proof":["not is_surjective_fn[A, B](f)"]}
+{"goal":"relation_pushforward[A, B](f, relation_pullback[A, B](f, r), p, q) = r(p, q)","proof":[]}
+{"goal":"relation_pushforward_pullback_of_surjective_at","proof":[]}
 {"goal":"u(p, q) = r(p, q)","proof":[]}
 {"goal":"relation_pushforward_pullback_of_surjective","proof":["let w0: B satisfy { r(w0) != relation_pushforward[A, B](f, relation_pullback[A, B](f, r), w0) }","let w1: B satisfy { r(w0, w1) != relation_pushforward[A, B](f, relation_pullback[A, B](f, r), w0, w1) }","function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T1, x3: T1) { not is_surjective_fn[T0, T1](x0) or relation_pushforward[T0, T1](x0, relation_pullback[T0, T1](x0, x1), x2, x3) = x1(x2, x3) }[A, B](f, r, w0, w1)"]}
 {"goal":"u(x, y) = relation_converse(r, f(x), f(y))","proof":["function(x0: A, x1: A) { relation_pullback[A, B](f, relation_converse[B, B](r), x0, x1) = u(x0, x1) }(x, y)","function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[A, B](f, relation_converse[B, B](r), x, y)"]}
@@ -180,6 +325,51 @@
 {"goal":"p(x) = p(y)","proof":[]}
 {"goal":"p(x)","proof":[]}
 {"goal":"respects_predicate_backward","proof":[]}
+{"goal":"respects_equivalence[T, U](f, r, s) = forall(x0: T, x1: T) { r(x0, x1) implies s(f(x0), f(x1)) }","proof":["function[T0, T2](x0: (T0, T0) -> Bool, x1: (T2, T2) -> Bool, x2: T0 -> T2) { forall(x3: T0, x4: T0) { not x0(x3, x4) or x1(x2(x3), x2(x4)) } = respects_equivalence[T0, T2](x2, x0, x1) }[T, U](r, s, f)"]}
+{"goal":"s(f(x), f(y))","proof":["respects_equivalence[T, U](f, r, s)","(forall(x0: T, x1: T) { not r(x0, x1) or s(f(x0), f(x1)) } = true)","function(x0: T) { forall(x1: T) { not r(x0, x1) or s(f(x0), f(x1)) } = true }(x)","function(x0: T, x1: T) { not (r(x0, x1) and not s(f(x0), f(x1))) }(x, y)"]}
+{"goal":"p(f(x)) = p(f(y))","proof":[]}
+{"goal":"predicate_pullback[T, U](f, p, x) = p(f(x))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[T, U](f, p, x)"]}
+{"goal":"predicate_pullback[T, U](f, p, y) = p(f(y))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[T, U](f, p, y)"]}
+{"goal":"predicate_pullback[T, U](f, p, x) = predicate_pullback[T, U](f, p, y)","proof":[]}
+{"goal":"respects_predicate[T](r, predicate_pullback[T, U](f, p)) = respects_function[T, Bool](r, predicate_pullback[T, U](f, p))","proof":["function[T0](x0: (T0, T0) -> Bool, x1: T0 -> Bool) { respects_function[T0, Bool](x0, x1) = respects_predicate[T0](x0, x1) }[T](r, predicate_pullback[T, U](f, p))"]}
+{"goal":"respects_function[T, Bool](r, predicate_pullback[T, U](f, p)) = forall(x0: T, x1: T) { r(x0, x1) implies predicate_pullback[T, U](f, p, x0) = predicate_pullback[T, U](f, p, x1) }","proof":["function[T0, T2](x0: (T0, T0) -> Bool, x1: T0 -> T2) { forall(x2: T0, x3: T0) { not x0(x2, x3) or x1(x3) = x1(x2) } = respects_function[T0, T2](x0, x1) }[T, Bool](r, predicate_pullback[T, U](f, p))"]}
+{"goal":"respects_predicate[T](r, predicate_pullback[T, U](f, p))","proof":["not respects_function[T, Bool](r, predicate_pullback[T, U](f, p))","let w0: T satisfy { exists(k0: T) { r(w0, k0) and predicate_pullback[T, U](f, p, k0) != predicate_pullback[T, U](f, p, w0) } }","let w1: T satisfy { r(w0, w1) and predicate_pullback[T, U](f, p, w1) != predicate_pullback[T, U](f, p, w0) }","function(x0: T, x1: T) { not r(x0, x1) or predicate_pullback[T, U](f, p, x0) = predicate_pullback[T, U](f, p, x1) }(w0, w1)","r(w0, w1)","predicate_pullback[T, U](f, p, w1) != predicate_pullback[T, U](f, p, w0)","predicate_pullback[T, U](f, p, w1) = predicate_pullback[T, U](f, p, w0)"]}
+{"goal":"predicate_pullback_respects_predicate_of_respects_equivalence","proof":[]}
+{"goal":"relation_pullback[T, U](f, s, x, y) = s(f(x), f(y))","proof":["function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[T, U](f, s, x, y)"]}
+{"goal":"s(f(x), f(y))","proof":[]}
+{"goal":"p(f(x)) = p(f(y))","proof":[]}
+{"goal":"predicate_pullback[T, U](f, p, x) = p(f(x))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[T, U](f, p, x)"]}
+{"goal":"predicate_pullback[T, U](f, p, y) = p(f(y))","proof":["function[T0, T1](x0: T0 -> T1, x1: T1 -> Bool, x2: T0) { predicate_pullback[T0, T1](x0, x1, x2) = x1(x0(x2)) }[T, U](f, p, y)"]}
+{"goal":"predicate_pullback[T, U](f, p, x) = predicate_pullback[T, U](f, p, y)","proof":[]}
+{"goal":"respects_predicate[T](relation_pullback[T, U](f, s), predicate_pullback[T, U](f, p)) = respects_function[T, Bool](relation_pullback[T, U](f, s), predicate_pullback[T, U](f, p))","proof":["function[T0](x0: (T0, T0) -> Bool, x1: T0 -> Bool) { respects_function[T0, Bool](x0, x1) = respects_predicate[T0](x0, x1) }[T](relation_pullback[T, U](f, s), predicate_pullback[T, U](f, p))"]}
+{"goal":"respects_function[T, Bool](relation_pullback[T, U](f, s), predicate_pullback[T, U](f, p)) = forall(x0: T, x1: T) { relation_pullback[T, U](f, s, x0, x1) implies predicate_pullback[T, U](f, p, x0) = predicate_pullback[T, U](f, p, x1) }","proof":["function[T0, T2](x0: (T0, T0) -> Bool, x1: T0 -> T2) { forall(x2: T0, x3: T0) { not x0(x2, x3) or x1(x3) = x1(x2) } = respects_function[T0, T2](x0, x1) }[T, Bool](relation_pullback[T, U](f, s), predicate_pullback[T, U](f, p))"]}
+{"goal":"respects_predicate[T](relation_pullback[T, U](f, s), predicate_pullback[T, U](f, p))","proof":["not respects_function[T, Bool](relation_pullback[T, U](f, s), predicate_pullback[T, U](f, p))","let w0: T satisfy { exists(k0: T) { relation_pullback[T, U](f, s, w0, k0) and predicate_pullback[T, U](f, p, k0) != predicate_pullback[T, U](f, p, w0) } }","let w1: T satisfy { relation_pullback[T, U](f, s, w0, w1) and predicate_pullback[T, U](f, p, w1) != predicate_pullback[T, U](f, p, w0) }","function(x0: T, x1: T) { not relation_pullback[T, U](f, s, x0, x1) or predicate_pullback[T, U](f, p, x0) = predicate_pullback[T, U](f, p, x1) }(w0, w1)","relation_pullback[T, U](f, s, w0, w1)","predicate_pullback[T, U](f, p, w1) != predicate_pullback[T, U](f, p, w0)","predicate_pullback[T, U](f, p, w1) = predicate_pullback[T, U](f, p, w0)"]}
+{"goal":"predicate_pullback_respects_predicate","proof":[]}
+{"goal":"exists(k0: T) { exists(k1: T) { f(k0) = u and f(k1) = v and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: T) { f(a) = u and f(k0) = v and r(a, k0) }","proof":[]}
+{"goal":"exists(k0: T) { f(k0) = u and p(k0) }","proof":[]}
+{"goal":"f(x) = f(a)","proof":[]}
+{"goal":"x = a","proof":[]}
+{"goal":"p(a)","proof":[]}
+{"goal":"p(b)","proof":[]}
+{"goal":"predicate_pushforward[T, U](f, p, f(b))","proof":[]}
+{"goal":"predicate_pushforward[T, U](f, p, v)","proof":[]}
+{"goal":"exists(k0: T) { f(k0) = v and p(k0) }","proof":[]}
+{"goal":"f(y) = f(b)","proof":[]}
+{"goal":"y = b","proof":[]}
+{"goal":"p(b)","proof":[]}
+{"goal":"r(b, a)","proof":[]}
+{"goal":"p(a)","proof":[]}
+{"goal":"predicate_pushforward[T, U](f, p, f(a))","proof":[]}
+{"goal":"predicate_pushforward[T, U](f, p, u)","proof":[]}
+{"goal":"predicate_pushforward[T, U](f, p, u) = predicate_pushforward[T, U](f, p, v)","proof":[]}
+{"goal":"respects_predicate[U](relation_pushforward[T, U](f, r), predicate_pushforward[T, U](f, p)) = respects_function[U, Bool](relation_pushforward[T, U](f, r), predicate_pushforward[T, U](f, p))","proof":["function[T0](x0: (T0, T0) -> Bool, x1: T0 -> Bool) { respects_function[T0, Bool](x0, x1) = respects_predicate[T0](x0, x1) }[U](relation_pushforward[T, U](f, r), predicate_pushforward[T, U](f, p))"]}
+{"goal":"respects_function[U, Bool](relation_pushforward[T, U](f, r), predicate_pushforward[T, U](f, p)) = forall(x0: U, x1: U) { relation_pushforward[T, U](f, r, x0, x1) implies predicate_pushforward[T, U](f, p, x0) = predicate_pushforward[T, U](f, p, x1) }","proof":["function[T0, T2](x0: (T0, T0) -> Bool, x1: T0 -> T2) { forall(x2: T0, x3: T0) { not x0(x2, x3) or x1(x3) = x1(x2) } = respects_function[T0, T2](x0, x1) }[U, Bool](relation_pushforward[T, U](f, r), predicate_pushforward[T, U](f, p))"]}
+{"goal":"respects_predicate[U](relation_pushforward[T, U](f, r), predicate_pushforward[T, U](f, p))","proof":["not respects_function[U, Bool](relation_pushforward[T, U](f, r), predicate_pushforward[T, U](f, p))","let w0: U satisfy { exists(k0: U) { relation_pushforward[T, U](f, r, w0, k0) and predicate_pushforward[T, U](f, p, k0) != predicate_pushforward[T, U](f, p, w0) } }","let w1: U satisfy { relation_pushforward[T, U](f, r, w0, w1) and predicate_pushforward[T, U](f, p, w1) != predicate_pushforward[T, U](f, p, w0) }","function(x0: U, x1: U) { not relation_pushforward[T, U](f, r, x0, x1) or predicate_pushforward[T, U](f, p, x0) = predicate_pushforward[T, U](f, p, x1) }(w0, w1)","relation_pushforward[T, U](f, r, w0, w1)","predicate_pushforward[T, U](f, p, w1) != predicate_pushforward[T, U](f, p, w0)","predicate_pushforward[T, U](f, p, w1) = predicate_pushforward[T, U](f, p, w0)"]}
+{"goal":"predicate_pushforward_respects_predicate_of_injective_symmetric","proof":[]}
+{"goal":"is_symmetric[T](r)","proof":[]}
+{"goal":"respects_predicate[U](relation_pushforward[T, U](f, r), predicate_pushforward[T, U](f, p))","proof":[]}
+{"goal":"predicate_pushforward_respects_predicate_of_injective_equivalence","proof":[]}
 {"goal":"u(x, y) = r(identity_fn(x), identity_fn(y))","proof":["function(x0: T, x1: T) { relation_pullback(identity_fn[T], r, x0, x1) = u(x0, x1) }(x, y)","function[T0, T1](x0: T0 -> T1, x1: (T1, T1) -> Bool, x2: T0, x3: T0) { relation_pullback[T0, T1](x0, x1, x2, x3) = x1(x0(x2), x0(x3)) }[T, T](identity_fn[T], r, x, y)"]}
 {"goal":"identity_fn(x) = x","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](x)"]}
 {"goal":"identity_fn(y) = y","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[T](y)"]}

--- a/projects/translate-mathlib/foundations/transport-across-equality/todo.md
+++ b/projects/translate-mathlib/foundations/transport-across-equality/todo.md
@@ -3,7 +3,7 @@
 Goal: support moving data and theorems across definitional boundaries in a controlled way.
 
 - [ ] Add basic transport lemmas across equality of types and structures
-- [ ] Extend relation pushforward transport into predicate and function transport across bijections
+- [ ] Add function transport across bijections after choosing the representation for transported functions
 - [ ] Add structure-preservation lemmas for transported algebraic data
 - [ ] Add helper lemmas for rewriting bundled objects by equality of underlying data
 - [ ] Add coercion-friendly equivalence wrappers where they reduce proof friction

--- a/src/relation_transport.ac
+++ b/src/relation_transport.ac
@@ -1,6 +1,6 @@
 /// Transport and compatibility lemmas for unbundled relations along functions.
 
-from functions import compose, identity_fn, binary_function_extensionality, is_injective_fn, is_surjective_fn, is_bijection_fn, bijection_fn_is_injective, bijection_fn_is_surjective, injective_fn_eq, surjective_fn_has_preimage
+from functions import compose, identity_fn, predicate_extensionality, binary_function_extensionality, is_injective_fn, is_surjective_fn, is_bijection_fn, bijection_fn_is_injective, bijection_fn_is_surjective, injective_fn_eq, surjective_fn_has_preimage
 from relation_basic import eq_relation, is_reflexive, is_irreflexive, is_symmetric, is_asymmetric, is_transitive, is_total, is_antisymmetric, is_equivalence, is_partial_equivalence, relation_intersection, relation_subset, relation_subset_refl, relation_subset_step, relation_subset_trans, relation_converse, relation_reflexive_closure, relation_symmetric_closure, eq_relation_is_equivalence, relation_intersection_is_equivalence, relation_converse_is_equivalence, equivalence_is_reflexive, equivalence_is_symmetric, equivalence_is_transitive, partial_equivalence_is_symmetric, partial_equivalence_is_transitive, reflexive_self, symmetric_flip, transitive_step, antisymmetric_eq
 
 /// The pullback of a homogeneous relation along a function.
@@ -12,6 +12,580 @@ define relation_pullback[A, B](f: A -> B, r: (B, B) -> Bool, x: A, y: A) -> Bool
 define relation_pushforward[A, B](f: A -> B, r: (A, A) -> Bool, u: B, v: B) -> Bool {
     exists(x: A, y: A) {
         f(x) = u and f(y) = v and r(x, y)
+    }
+}
+
+/// True if every element satisfying `p` also satisfies `q`.
+define predicate_subset[T](p: T -> Bool, q: T -> Bool) -> Bool {
+    forall(x: T) {
+        p(x) implies q(x)
+    }
+}
+
+/// The pullback of a predicate along a function.
+define predicate_pullback[A, B](f: A -> B, p: B -> Bool, x: A) -> Bool {
+    p(f(x))
+}
+
+/// The image of a predicate along a function.
+define predicate_pushforward[A, B](f: A -> B, p: A -> Bool, y: B) -> Bool {
+    exists(x: A) {
+        f(x) = y and p(x)
+    }
+}
+
+/// A predicate inclusion applies to an explicitly satisfying element.
+theorem predicate_subset_step[T](p: T -> Bool, q: T -> Bool, x: T) {
+    predicate_subset(p, q) and p(x) implies q(x)
+} by {
+    if predicate_subset(p, q) and p(x) {
+        predicate_subset(p, q) = forall(y: T) {
+            p(y) implies q(y)
+        }
+        q(x)
+    }
+}
+
+/// Every predicate is contained in itself.
+theorem predicate_subset_refl[T](p: T -> Bool) {
+    predicate_subset(p, p)
+} by {
+    forall(x: T) {
+        if p(x) {
+            p(x)
+        }
+    }
+}
+
+/// Predicate inclusion is transitive.
+theorem predicate_subset_trans[T](p: T -> Bool, q: T -> Bool, r: T -> Bool) {
+    predicate_subset(p, q) and predicate_subset(q, r) implies predicate_subset(p, r)
+} by {
+    if predicate_subset(p, q) and predicate_subset(q, r) {
+        forall(x: T) {
+            if p(x) {
+                predicate_subset_step(p, q, x)
+                q(x)
+                predicate_subset_step(q, r, x)
+                r(x)
+            }
+        }
+    }
+}
+
+/// Predicate equality is equivalent to mutual inclusion.
+theorem predicate_eq_iff_subset_both[T](p: T -> Bool, q: T -> Bool) {
+    p = q = (predicate_subset(p, q) and predicate_subset(q, p))
+} by {
+    if p = q {
+        predicate_subset_refl(p)
+        predicate_subset(p, q)
+        predicate_subset(q, p)
+        predicate_subset(p, q) and predicate_subset(q, p)
+    }
+    if predicate_subset(p, q) and predicate_subset(q, p) {
+        forall(x: T) {
+            if p(x) {
+                predicate_subset_step(p, q, x)
+                q(x)
+            }
+            if q(x) {
+                predicate_subset_step(q, p, x)
+                p(x)
+            }
+            p(x) = q(x)
+        }
+        predicate_extensionality(p, q)
+        p = q
+    }
+    p = q = (predicate_subset(p, q) and predicate_subset(q, p))
+}
+
+/// An element satisfying a predicate gives an element satisfying its pushforward.
+theorem predicate_pushforward_intro[A, B](f: A -> B, p: A -> Bool, x: A) {
+    p(x) implies predicate_pushforward(f, p, f(x))
+} by {
+    if p(x) {
+        exists(a: A) {
+            a = x and f(a) = f(x) and p(a)
+        }
+        predicate_pushforward(f, p, f(x))
+    }
+}
+
+/// A pushed-forward predicate instance has a preimage satisfying the source predicate.
+theorem predicate_pushforward_has_preimage[A, B](f: A -> B, p: A -> Bool, y: B) {
+    predicate_pushforward(f, p, y) implies exists(x: A) {
+        f(x) = y and p(x)
+    }
+} by {
+    if predicate_pushforward(f, p, y) {
+        exists(x: A) {
+            f(x) = y and p(x)
+        }
+    }
+}
+
+/// Pulling back along the identity function leaves a predicate unchanged.
+theorem predicate_pullback_identity[T](p: T -> Bool) {
+    predicate_pullback(identity_fn[T], p) = p
+} by {
+    let u = predicate_pullback(identity_fn[T], p)
+    let v = p
+    forall(x: T) {
+        u(x) = p(identity_fn[T](x))
+        identity_fn[T](x) = x
+        u(x) = v(x)
+    }
+    predicate_extensionality(u, v)
+}
+
+/// Pushing forward along the identity function leaves a predicate unchanged.
+theorem predicate_pushforward_identity[T](p: T -> Bool) {
+    predicate_pushforward(identity_fn[T], p) = p
+} by {
+    let u = predicate_pushforward(identity_fn[T], p)
+    let v = p
+    forall(x: T) {
+        if u(x) {
+            predicate_pushforward_has_preimage(identity_fn[T], p, x)
+            let a: T satisfy {
+                identity_fn[T](a) = x and p(a)
+            }
+            identity_fn[T](a) = a
+            a = x
+            v(x)
+        }
+        if v(x) {
+            predicate_pushforward_intro(identity_fn[T], p, x)
+            identity_fn[T](x) = x
+            u(x)
+        }
+        u(x) = v(x)
+    }
+    predicate_extensionality(u, v)
+}
+
+/// Predicate pullback respects function composition.
+theorem predicate_pullback_compose[A, B, C](g: A -> B, f: B -> C, p: C -> Bool) {
+    predicate_pullback(compose(f, g), p) = predicate_pullback(g, predicate_pullback(f, p))
+} by {
+    let u = predicate_pullback(compose(f, g), p)
+    let v = predicate_pullback(g, predicate_pullback(f, p))
+    forall(x: A) {
+        u(x) = p(compose(f, g)(x))
+        compose(f, g, x) = f(g(x))
+        v(x) = predicate_pullback(f, p, g(x))
+        predicate_pullback(f, p, g(x)) = p(f(g(x)))
+        u(x) = v(x)
+    }
+    predicate_extensionality(u, v)
+}
+
+/// Predicate pushforward respects function composition.
+theorem predicate_pushforward_compose[A, B, C](g: A -> B, f: B -> C, p: A -> Bool) {
+    predicate_pushforward(compose(f, g), p) = predicate_pushforward(f, predicate_pushforward(g, p))
+} by {
+    let u = predicate_pushforward(compose(f, g), p)
+    let v = predicate_pushforward(f, predicate_pushforward(g, p))
+    forall(z: C) {
+        if u(z) {
+            predicate_pushforward_has_preimage(compose(f, g), p, z)
+            let x: A satisfy {
+                compose(f, g)(x) = z and p(x)
+            }
+            compose(f, g, x) = f(g(x))
+            predicate_pushforward_intro(g, p, x)
+            predicate_pushforward(g, p, g(x))
+            exists(y: B) {
+                y = g(x) and f(y) = z and predicate_pushforward(g, p, y)
+            }
+            predicate_pushforward(f, predicate_pushforward(g, p), z)
+            v(z)
+        }
+        if v(z) {
+            predicate_pushforward_has_preimage(f, predicate_pushforward(g, p), z)
+            let y: B satisfy {
+                f(y) = z and predicate_pushforward(g, p, y)
+            }
+            predicate_pushforward_has_preimage(g, p, y)
+            let x: A satisfy {
+                g(x) = y and p(x)
+            }
+            compose(f, g, x) = f(g(x))
+            compose(f, g)(x) = z
+            exists(a: A) {
+                a = x and compose(f, g)(a) = z and p(a)
+            }
+            predicate_pushforward(compose(f, g), p, z)
+            u(z)
+        }
+        u(z) = v(z)
+    }
+    predicate_extensionality(u, v)
+}
+
+/// Predicate pullback is monotone with respect to inclusion.
+theorem predicate_pullback_monotone[A, B](f: A -> B, p: B -> Bool, q: B -> Bool) {
+    predicate_subset(p, q) implies predicate_subset(predicate_pullback(f, p), predicate_pullback(f, q))
+} by {
+    if predicate_subset(p, q) {
+        forall(x: A) {
+            if predicate_pullback(f, p, x) {
+                predicate_pullback(f, p, x) = p(f(x))
+                p(f(x))
+                predicate_subset_step(p, q, f(x))
+                q(f(x))
+                predicate_pullback(f, q, x)
+            }
+        }
+    }
+}
+
+/// Predicate pushforward is monotone with respect to inclusion.
+theorem predicate_pushforward_monotone[A, B](f: A -> B, p: A -> Bool, q: A -> Bool) {
+    predicate_subset(p, q) implies predicate_subset(predicate_pushforward(f, p), predicate_pushforward(f, q))
+} by {
+    if predicate_subset(p, q) {
+        forall(y: B) {
+            if predicate_pushforward(f, p, y) {
+                predicate_pushforward_has_preimage(f, p, y)
+                let x: A satisfy {
+                    f(x) = y and p(x)
+                }
+                predicate_subset_step(p, q, x)
+                q(x)
+                exists(a: A) {
+                    a = x and f(a) = y and q(a)
+                }
+                predicate_pushforward(f, q, y)
+            }
+        }
+    }
+}
+
+/// Pullback after pushforward contains the original predicate.
+theorem predicate_subset_pullback_pushforward[A, B](f: A -> B, p: A -> Bool) {
+    predicate_subset(p, predicate_pullback(f, predicate_pushforward(f, p)))
+} by {
+    forall(x: A) {
+        if p(x) {
+            predicate_pushforward_intro(f, p, x)
+            predicate_pushforward(f, p, f(x))
+            predicate_pullback(f, predicate_pushforward(f, p), x)
+        }
+    }
+}
+
+/// Pullback after pushforward recovers each original predicate instance along injective functions.
+theorem predicate_pullback_pushforward_of_injective_at[A, B](f: A -> B, p: A -> Bool, x: A) {
+    is_injective_fn(f) implies predicate_pullback(f, predicate_pushforward(f, p), x) = p(x)
+} by {
+    if is_injective_fn(f) {
+        if predicate_pullback(f, predicate_pushforward(f, p), x) {
+            predicate_pullback(f, predicate_pushforward(f, p), x) = predicate_pushforward(f, p, f(x))
+            predicate_pushforward_has_preimage(f, p, f(x))
+            let a: A satisfy {
+                f(a) = f(x) and p(a)
+            }
+            injective_fn_eq(f, a, x)
+            a = x
+            p(x)
+        }
+        if p(x) {
+            predicate_subset_pullback_pushforward(f, p)
+            predicate_pullback(f, predicate_pushforward(f, p), x)
+        }
+        predicate_pullback(f, predicate_pushforward(f, p), x) = p(x)
+    }
+}
+
+/// Pullback after pushforward recovers the original predicate along injective functions.
+theorem predicate_pullback_pushforward_of_injective[A, B](f: A -> B, p: A -> Bool) {
+    is_injective_fn(f) implies predicate_pullback(f, predicate_pushforward(f, p)) = p
+} by {
+    let u = predicate_pullback(f, predicate_pushforward(f, p))
+    let v = p
+    if is_injective_fn(f) {
+        forall(x: A) {
+            predicate_pullback_pushforward_of_injective_at(f, p, x)
+            u(x) = v(x)
+        }
+        predicate_extensionality(u, v)
+    }
+}
+
+/// Pushforward after pullback is contained in the target predicate.
+theorem predicate_subset_pushforward_pullback[A, B](f: A -> B, p: B -> Bool) {
+    predicate_subset(predicate_pushforward(f, predicate_pullback(f, p)), p)
+} by {
+    forall(y: B) {
+        if predicate_pushforward(f, predicate_pullback(f, p), y) {
+            predicate_pushforward_has_preimage(f, predicate_pullback(f, p), y)
+            let x: A satisfy {
+                f(x) = y and predicate_pullback(f, p, x)
+            }
+            predicate_pullback(f, p, x) = p(f(x))
+            p(f(x))
+            p(y)
+        }
+    }
+}
+
+/// Pushforward after pullback recovers each target predicate instance along surjective functions.
+theorem predicate_pushforward_pullback_of_surjective_at[A, B](f: A -> B, p: B -> Bool, y: B) {
+    is_surjective_fn(f) implies predicate_pushforward(f, predicate_pullback(f, p), y) = p(y)
+} by {
+    if is_surjective_fn(f) {
+        if predicate_pushforward(f, predicate_pullback(f, p), y) {
+            predicate_subset_pushforward_pullback(f, p)
+            p(y)
+        }
+        if p(y) {
+            surjective_fn_has_preimage(f, y)
+            let x: A satisfy {
+                f(x) = y
+            }
+            predicate_pullback(f, p, x) = p(f(x))
+            predicate_pullback(f, p, x)
+            exists(a: A) {
+                a = x and f(a) = y and predicate_pullback(f, p, a)
+            }
+            predicate_pushforward(f, predicate_pullback(f, p), y)
+        }
+        predicate_pushforward(f, predicate_pullback(f, p), y) = p(y)
+    }
+}
+
+/// Pushforward after pullback recovers the target predicate along surjective functions.
+theorem predicate_pushforward_pullback_of_surjective[A, B](f: A -> B, p: B -> Bool) {
+    is_surjective_fn(f) implies predicate_pushforward(f, predicate_pullback(f, p)) = p
+} by {
+    let u = predicate_pushforward(f, predicate_pullback(f, p))
+    let v = p
+    if is_surjective_fn(f) {
+        forall(y: B) {
+            predicate_pushforward_pullback_of_surjective_at(f, p, y)
+            u(y) = v(y)
+        }
+        predicate_extensionality(u, v)
+    }
+}
+
+/// Bijective pullback after pushforward recovers the original predicate.
+theorem predicate_pullback_pushforward_of_bijection[A, B](f: A -> B, p: A -> Bool) {
+    is_bijection_fn(f) implies predicate_pullback(f, predicate_pushforward(f, p)) = p
+} by {
+    if is_bijection_fn(f) {
+        bijection_fn_is_injective(f)
+        predicate_pullback_pushforward_of_injective(f, p)
+        predicate_pullback(f, predicate_pushforward(f, p)) = p
+    }
+}
+
+/// Bijective pushforward after pullback recovers the target predicate.
+theorem predicate_pushforward_pullback_of_bijection[A, B](f: A -> B, p: B -> Bool) {
+    is_bijection_fn(f) implies predicate_pushforward(f, predicate_pullback(f, p)) = p
+} by {
+    if is_bijection_fn(f) {
+        bijection_fn_is_surjective(f)
+        predicate_pushforward_pullback_of_surjective(f, p)
+        predicate_pushforward(f, predicate_pullback(f, p)) = p
+    }
+}
+
+/// Surjective pullback reflects predicate inclusion.
+theorem predicate_pullback_subset_imp_subset_of_surjective[A, B](f: A -> B, p: B -> Bool, q: B -> Bool) {
+    is_surjective_fn(f) and predicate_subset(predicate_pullback(f, p), predicate_pullback(f, q)) implies
+    predicate_subset(p, q)
+} by {
+    if is_surjective_fn(f) and predicate_subset(predicate_pullback(f, p), predicate_pullback(f, q)) {
+        forall(y: B) {
+            if p(y) {
+                surjective_fn_has_preimage(f, y)
+                let x: A satisfy {
+                    f(x) = y
+                }
+                predicate_pullback(f, p, x) = p(f(x))
+                predicate_pullback(f, p, x)
+                predicate_subset_step(predicate_pullback(f, p), predicate_pullback(f, q), x)
+                predicate_pullback(f, q, x)
+                predicate_pullback(f, q, x) = q(f(x))
+                q(y)
+            }
+        }
+    }
+}
+
+/// Surjective pullback detects predicate inclusion.
+theorem predicate_pullback_subset_iff_of_surjective[A, B](f: A -> B, p: B -> Bool, q: B -> Bool) {
+    is_surjective_fn(f) implies
+    predicate_subset(predicate_pullback(f, p), predicate_pullback(f, q)) = predicate_subset(p, q)
+} by {
+    if is_surjective_fn(f) {
+        if predicate_subset(predicate_pullback(f, p), predicate_pullback(f, q)) {
+            predicate_pullback_subset_imp_subset_of_surjective(f, p, q)
+            predicate_subset(p, q)
+        }
+        if predicate_subset(p, q) {
+            predicate_pullback_monotone(f, p, q)
+            predicate_subset(predicate_pullback(f, p), predicate_pullback(f, q))
+        }
+        predicate_subset(predicate_pullback(f, p), predicate_pullback(f, q)) = predicate_subset(p, q)
+    }
+}
+
+/// Surjective pullback reflects predicate equality.
+theorem predicate_pullback_eq_imp_eq_of_surjective[A, B](f: A -> B, p: B -> Bool, q: B -> Bool) {
+    is_surjective_fn(f) and predicate_pullback(f, p) = predicate_pullback(f, q) implies p = q
+} by {
+    if is_surjective_fn(f) and predicate_pullback(f, p) = predicate_pullback(f, q) {
+        predicate_eq_iff_subset_both(predicate_pullback(f, p), predicate_pullback(f, q))
+        predicate_subset(predicate_pullback(f, p), predicate_pullback(f, q))
+        predicate_subset(predicate_pullback(f, q), predicate_pullback(f, p))
+        predicate_pullback_subset_imp_subset_of_surjective(f, p, q)
+        predicate_subset(p, q)
+        predicate_pullback_subset_imp_subset_of_surjective(f, q, p)
+        predicate_subset(q, p)
+        predicate_eq_iff_subset_both(p, q)
+        p = q
+    }
+}
+
+/// Pullback along a surjective function detects predicate equality.
+theorem predicate_pullback_eq_iff_of_surjective[A, B](f: A -> B, p: B -> Bool, q: B -> Bool) {
+    is_surjective_fn(f) implies (predicate_pullback(f, p) = predicate_pullback(f, q)) = (p = q)
+} by {
+    if is_surjective_fn(f) {
+        if predicate_pullback(f, p) = predicate_pullback(f, q) {
+            predicate_pullback_eq_imp_eq_of_surjective(f, p, q)
+            p = q
+        }
+        if p = q {
+            predicate_pullback(f, p) = predicate_pullback(f, q)
+        }
+        (predicate_pullback(f, p) = predicate_pullback(f, q)) = (p = q)
+    }
+}
+
+/// Injective pushforward reflects predicate inclusion.
+theorem predicate_pushforward_subset_imp_subset_of_injective[A, B](f: A -> B, p: A -> Bool, q: A -> Bool) {
+    is_injective_fn(f) and predicate_subset(predicate_pushforward(f, p), predicate_pushforward(f, q)) implies
+    predicate_subset(p, q)
+} by {
+    if is_injective_fn(f) and predicate_subset(predicate_pushforward(f, p), predicate_pushforward(f, q)) {
+        forall(x: A) {
+            if p(x) {
+                predicate_pushforward_intro(f, p, x)
+                predicate_pushforward(f, p, f(x))
+                predicate_subset_step(predicate_pushforward(f, p), predicate_pushforward(f, q), f(x))
+                predicate_pushforward(f, q, f(x))
+                predicate_pushforward_has_preimage(f, q, f(x))
+                let a: A satisfy {
+                    f(a) = f(x) and q(a)
+                }
+                injective_fn_eq(f, a, x)
+                a = x
+                q(x)
+            }
+        }
+    }
+}
+
+/// Injective pushforward detects predicate inclusion.
+theorem predicate_pushforward_subset_iff_of_injective[A, B](f: A -> B, p: A -> Bool, q: A -> Bool) {
+    is_injective_fn(f) implies
+    predicate_subset(predicate_pushforward(f, p), predicate_pushforward(f, q)) = predicate_subset(p, q)
+} by {
+    if is_injective_fn(f) {
+        if predicate_subset(predicate_pushforward(f, p), predicate_pushforward(f, q)) {
+            predicate_pushforward_subset_imp_subset_of_injective(f, p, q)
+            predicate_subset(p, q)
+        }
+        if predicate_subset(p, q) {
+            predicate_pushforward_monotone(f, p, q)
+            predicate_subset(predicate_pushforward(f, p), predicate_pushforward(f, q))
+        }
+        predicate_subset(predicate_pushforward(f, p), predicate_pushforward(f, q)) = predicate_subset(p, q)
+    }
+}
+
+/// Injective pushforward reflects predicate equality.
+theorem predicate_pushforward_eq_imp_eq_of_injective[A, B](f: A -> B, p: A -> Bool, q: A -> Bool) {
+    is_injective_fn(f) and predicate_pushforward(f, p) = predicate_pushforward(f, q) implies p = q
+} by {
+    if is_injective_fn(f) and predicate_pushforward(f, p) = predicate_pushforward(f, q) {
+        predicate_eq_iff_subset_both(predicate_pushforward(f, p), predicate_pushforward(f, q))
+        predicate_subset(predicate_pushforward(f, p), predicate_pushforward(f, q))
+        predicate_subset(predicate_pushforward(f, q), predicate_pushforward(f, p))
+        predicate_pushforward_subset_imp_subset_of_injective(f, p, q)
+        predicate_subset(p, q)
+        predicate_pushforward_subset_imp_subset_of_injective(f, q, p)
+        predicate_subset(q, p)
+        predicate_eq_iff_subset_both(p, q)
+        p = q
+    }
+}
+
+/// Pushforward along an injective function detects predicate equality.
+theorem predicate_pushforward_eq_iff_of_injective[A, B](f: A -> B, p: A -> Bool, q: A -> Bool) {
+    is_injective_fn(f) implies (predicate_pushforward(f, p) = predicate_pushforward(f, q)) = (p = q)
+} by {
+    if is_injective_fn(f) {
+        if predicate_pushforward(f, p) = predicate_pushforward(f, q) {
+            predicate_pushforward_eq_imp_eq_of_injective(f, p, q)
+            p = q
+        }
+        if p = q {
+            predicate_pushforward(f, p) = predicate_pushforward(f, q)
+        }
+        (predicate_pushforward(f, p) = predicate_pushforward(f, q)) = (p = q)
+    }
+}
+
+/// Bijective pullback detects predicate inclusion.
+theorem predicate_pullback_subset_iff_of_bijection[A, B](f: A -> B, p: B -> Bool, q: B -> Bool) {
+    is_bijection_fn(f) implies
+    predicate_subset(predicate_pullback(f, p), predicate_pullback(f, q)) = predicate_subset(p, q)
+} by {
+    if is_bijection_fn(f) {
+        bijection_fn_is_surjective(f)
+        predicate_pullback_subset_iff_of_surjective(f, p, q)
+        predicate_subset(predicate_pullback(f, p), predicate_pullback(f, q)) = predicate_subset(p, q)
+    }
+}
+
+/// Bijective pushforward detects predicate inclusion.
+theorem predicate_pushforward_subset_iff_of_bijection[A, B](f: A -> B, p: A -> Bool, q: A -> Bool) {
+    is_bijection_fn(f) implies
+    predicate_subset(predicate_pushforward(f, p), predicate_pushforward(f, q)) = predicate_subset(p, q)
+} by {
+    if is_bijection_fn(f) {
+        bijection_fn_is_injective(f)
+        predicate_pushforward_subset_iff_of_injective(f, p, q)
+        predicate_subset(predicate_pushforward(f, p), predicate_pushforward(f, q)) = predicate_subset(p, q)
+    }
+}
+
+/// Bijective pullback detects predicate equality.
+theorem predicate_pullback_eq_iff_of_bijection[A, B](f: A -> B, p: B -> Bool, q: B -> Bool) {
+    is_bijection_fn(f) implies (predicate_pullback(f, p) = predicate_pullback(f, q)) = (p = q)
+} by {
+    if is_bijection_fn(f) {
+        bijection_fn_is_surjective(f)
+        predicate_pullback_eq_iff_of_surjective(f, p, q)
+        (predicate_pullback(f, p) = predicate_pullback(f, q)) = (p = q)
+    }
+}
+
+/// Bijective pushforward detects predicate equality.
+theorem predicate_pushforward_eq_iff_of_bijection[A, B](f: A -> B, p: A -> Bool, q: A -> Bool) {
+    is_bijection_fn(f) implies (predicate_pushforward(f, p) = predicate_pushforward(f, q)) = (p = q)
+} by {
+    if is_bijection_fn(f) {
+        bijection_fn_is_injective(f)
+        predicate_pushforward_eq_iff_of_injective(f, p, q)
+        (predicate_pushforward(f, p) = predicate_pushforward(f, q)) = (p = q)
     }
 }
 
@@ -657,6 +1231,148 @@ theorem respects_predicate_backward[T](r: (T, T) -> Bool, p: T -> Bool, x: T, y:
         respects_predicate_step_eq(r, p, x, y)
         p(x) = p(y)
         p(x)
+    }
+}
+
+/// Pulling back a relation-invariant predicate along a compatible function preserves invariance.
+theorem predicate_pullback_respects_predicate_of_respects_equivalence[T, U](
+    f: T -> U,
+    r: (T, T) -> Bool,
+    s: (U, U) -> Bool,
+    p: U -> Bool
+) {
+    respects_equivalence(f, r, s) and respects_predicate(s, p) implies
+    respects_predicate(r, predicate_pullback(f, p))
+} by {
+    if respects_equivalence(f, r, s) and respects_predicate(s, p) {
+        forall(x: T, y: T) {
+            if r(x, y) {
+                respects_equivalence(f, r, s) = forall(a: T, b: T) {
+                    r(a, b) implies s(f(a), f(b))
+                }
+                s(f(x), f(y))
+                respects_predicate_step_eq(s, p, f(x), f(y))
+                p(f(x)) = p(f(y))
+                predicate_pullback(f, p, x) = p(f(x))
+                predicate_pullback(f, p, y) = p(f(y))
+                predicate_pullback(f, p, x) = predicate_pullback(f, p, y)
+            }
+        }
+        respects_predicate(r, predicate_pullback(f, p)) =
+            respects_function(r, predicate_pullback(f, p))
+        respects_function(r, predicate_pullback(f, p)) = forall(x: T, y: T) {
+            r(x, y) implies predicate_pullback(f, p, x) = predicate_pullback(f, p, y)
+        }
+        respects_predicate(r, predicate_pullback(f, p))
+    }
+}
+
+/// Pulling back a relation-invariant predicate along any function preserves invariance for the pullback relation.
+theorem predicate_pullback_respects_predicate[T, U](f: T -> U, s: (U, U) -> Bool, p: U -> Bool) {
+    respects_predicate(s, p) implies respects_predicate(relation_pullback(f, s), predicate_pullback(f, p))
+} by {
+    if respects_predicate(s, p) {
+        forall(x: T, y: T) {
+            if relation_pullback(f, s, x, y) {
+                relation_pullback(f, s, x, y) = s(f(x), f(y))
+                s(f(x), f(y))
+                respects_predicate_step_eq(s, p, f(x), f(y))
+                p(f(x)) = p(f(y))
+                predicate_pullback(f, p, x) = p(f(x))
+                predicate_pullback(f, p, y) = p(f(y))
+                predicate_pullback(f, p, x) = predicate_pullback(f, p, y)
+            }
+        }
+        respects_predicate(relation_pullback(f, s), predicate_pullback(f, p)) =
+            respects_function(relation_pullback(f, s), predicate_pullback(f, p))
+        respects_function(relation_pullback(f, s), predicate_pullback(f, p)) = forall(x: T, y: T) {
+            relation_pullback(f, s, x, y) implies
+            predicate_pullback(f, p, x) = predicate_pullback(f, p, y)
+        }
+        respects_predicate(relation_pullback(f, s), predicate_pullback(f, p))
+    }
+}
+
+/// A predicate invariant under a symmetric relation has invariant pushforward along an injective function.
+theorem predicate_pushforward_respects_predicate_of_injective_symmetric[T, U](
+    f: T -> U,
+    r: (T, T) -> Bool,
+    p: T -> Bool
+) {
+    is_injective_fn(f) and is_symmetric(r) and respects_predicate(r, p) implies
+    respects_predicate(relation_pushforward(f, r), predicate_pushforward(f, p))
+} by {
+    if is_injective_fn(f) and is_symmetric(r) and respects_predicate(r, p) {
+        forall(u: U, v: U) {
+            if relation_pushforward(f, r, u, v) {
+                relation_pushforward_has_preimages(f, r, u, v)
+                let a: T satisfy {
+                    exists(b: T) {
+                        f(a) = u and f(b) = v and r(a, b)
+                    }
+                }
+                let b: T satisfy {
+                    f(a) = u and f(b) = v and r(a, b)
+                }
+                if predicate_pushforward(f, p, u) {
+                    predicate_pushforward_has_preimage(f, p, u)
+                    let x: T satisfy {
+                        f(x) = u and p(x)
+                    }
+                    f(x) = f(a)
+                    injective_fn_eq(f, x, a)
+                    x = a
+                    p(a)
+                    respects_predicate_forward(r, p, a, b)
+                    p(b)
+                    predicate_pushforward_intro(f, p, b)
+                    predicate_pushforward(f, p, f(b))
+                    predicate_pushforward(f, p, v)
+                }
+                if predicate_pushforward(f, p, v) {
+                    predicate_pushforward_has_preimage(f, p, v)
+                    let y: T satisfy {
+                        f(y) = v and p(y)
+                    }
+                    f(y) = f(b)
+                    injective_fn_eq(f, y, b)
+                    y = b
+                    p(b)
+                    symmetric_flip(r, a, b)
+                    r(b, a)
+                    respects_predicate_forward(r, p, b, a)
+                    p(a)
+                    predicate_pushforward_intro(f, p, a)
+                    predicate_pushforward(f, p, f(a))
+                    predicate_pushforward(f, p, u)
+                }
+                predicate_pushforward(f, p, u) = predicate_pushforward(f, p, v)
+            }
+        }
+        respects_predicate(relation_pushforward(f, r), predicate_pushforward(f, p)) =
+            respects_function(relation_pushforward(f, r), predicate_pushforward(f, p))
+        respects_function(relation_pushforward(f, r), predicate_pushforward(f, p)) = forall(u: U, v: U) {
+            relation_pushforward(f, r, u, v) implies
+            predicate_pushforward(f, p, u) = predicate_pushforward(f, p, v)
+        }
+        respects_predicate(relation_pushforward(f, r), predicate_pushforward(f, p))
+    }
+}
+
+/// A predicate invariant under an equivalence relation has invariant pushforward along an injective function.
+theorem predicate_pushforward_respects_predicate_of_injective_equivalence[T, U](
+    f: T -> U,
+    r: (T, T) -> Bool,
+    p: T -> Bool
+) {
+    is_injective_fn(f) and is_equivalence(r) and respects_predicate(r, p) implies
+    respects_predicate(relation_pushforward(f, r), predicate_pushforward(f, p))
+} by {
+    if is_injective_fn(f) and is_equivalence(r) and respects_predicate(r, p) {
+        equivalence_is_symmetric(r)
+        is_symmetric(r)
+        predicate_pushforward_respects_predicate_of_injective_symmetric(f, r, p)
+        respects_predicate(relation_pushforward(f, r), predicate_pushforward(f, p))
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds predicate pullback/pushforward operations and subset helpers to `relation_transport.ac`.
- Proves identity, composition, monotonicity, inclusion/equality reflection, and injective/surjective/bijective round-trip lemmas.
- Adds compatibility lemmas for relation-invariant predicates under pullback and injective pushforward, and narrows the translate-mathlib transport roadmap item toward the remaining function-transport design choice.

## Verification
- `acorn check`
- `git diff --check`
