### PR TITLE
feat: add bundled relation transport wrappers

### DIFF
--- a/build/finite_set.jsonl
+++ b/build/finite_set.jsonl
@@ -17,13 +17,13 @@
 {"goal":"exists(k0: FiniteSet[T]) { FiniteSet.new[T](a.underlying_set.difference(b.underlying_set)) = Option.some(k0) }","proof":["function[T0](x0: Set[T0]) { not FiniteSet.constraint[T0](x0) or exists(k0: FiniteSet[T0]) { FiniteSet.new[T0](x0) = Option.some[FiniteSet[T0]](k0) } }[T](a.underlying_set ∖ b.underlying_set)","function[T0](x0: Set[T0], x1: Set[T0]) { not x0.is_finite or (x0 ∖ x1).is_finite }[T](a.underlying_set, b.underlying_set)","function[T0](x0: Set[T0]) { x0.is_finite = FiniteSet.constraint[T0](x0) }[T](a.underlying_set ∖ b.underlying_set)","function[T0](x0: FiniteSet[T0]) { x0.underlying_set.is_finite }[T](a)"]}
 {"goal":"exists(k0: FiniteSet[U]) { FiniteSet.new[U](set_image[T, U](s.underlying_set, f)) = Option.some(k0) }","proof":["function[T0](x0: Set[T0]) { not FiniteSet.constraint[T0](x0) or exists(k0: FiniteSet[T0]) { FiniteSet.new[T0](x0) = Option.some[FiniteSet[T0]](k0) } }[U](set_image[T, U](s.underlying_set, f))","function[T0](x0: Set[T0]) { x0.is_finite = FiniteSet.constraint[T0](x0) }[U](set_image[T, U](s.underlying_set, f))","function[T0](x0: FiniteSet[T0]) { x0.underlying_set.is_finite }[T](s)"]}
 {"goal":"finite_set_ext","proof":["function[T0](x0: FiniteSet[T0]) { FiniteSet.new[T0](x0.underlying_set) = Option.some[FiniteSet[T0]](x0) }[T](a)","function[T0](x0: FiniteSet[T0]) { FiniteSet.new[T0](x0.underlying_set) = Option.some[FiniteSet[T0]](x0) }[T](b)","function[T0](x0: T0, x1: T0) { Option.some[T0](x0) != Option.some[T0](x1) or x0 = x1 }[FiniteSet[T]](b, a)"]}
-{"goal":"finite_set_eq_underlying_set","proof":["b != a"]}
-{"goal":"a.underlying_set = b.underlying_set","proof":["b != a"]}
-{"goal":"a.underlying_set.contains(x) = b.underlying_set.contains(x)","proof":["b.underlying_set != a.underlying_set"]}
-{"goal":"finite_set_eq_underlying_contains_at","proof":["b != a"]}
-{"goal":"finite_set_eq_transport_predicate","proof":["p(a)","b = a"]}
-{"goal":"finite_set_eq_transport_predicate_rev","proof":["p(b)","b = a"]}
-{"goal":"finite_set_eq_of_underlying_set_eq","proof":["b.underlying_set != a.underlying_set"]}
+{"goal":"finite_set_eq_underlying_set","proof":[]}
+{"goal":"a.underlying_set = b.underlying_set","proof":[]}
+{"goal":"a.underlying_set.contains(x) = b.underlying_set.contains(x)","proof":[]}
+{"goal":"finite_set_eq_underlying_contains_at","proof":[]}
+{"goal":"finite_set_eq_transport_predicate","proof":[]}
+{"goal":"finite_set_eq_transport_predicate_rev","proof":[]}
+{"goal":"finite_set_eq_of_underlying_set_eq","proof":[]}
 {"goal":"s.underlying_set.contains(x)","proof":["function[T0](x0: FiniteSet[T0], x1: T0 -> Bool, x2: T0) { set_witness_predicate[T0](x0.underlying_set, x1, x2) = finite_set_witness_predicate[T0](x0, x1, x2) }[T](s, p, x)"]}
 {"goal":"s.contains(x)","proof":["function[T0](x0: FiniteSet[T0], x1: T0) { x1 ∈ x0.underlying_set = x1 ∈ x0 }[T](s, x)"]}
 {"goal":"finite_set_witness_contains","proof":[]}

--- a/build/group.jsonl
+++ b/build/group.jsonl
@@ -40,15 +40,15 @@
 {"goal":"trivial_group_hom_is_hom","proof":["function[T0: Group, T1: Group](x0: T0 -> T1) { forall(x1: T0, x2: T0) { x0(x1 * x2) = x0(x1) * x0(x2) } = is_group_hom[T0, T1](x0) }[G, H](trivial_group_hom[G, H])","let w0: G satisfy { exists(k0: G) { trivial_group_hom[G, H](w0 * k0) != trivial_group_hom[G, H](w0) * trivial_group_hom[G, H](k0) } }","function[T0: Group, T1: Group](x0: T1) { T0.1 = trivial_group_hom[T1, T0](x0) }[H, G](w0)","function[T0: Monoid](x0: T0) { x0 * T0.1 = x0 }[H](trivial_group_hom[G, H](w0))","let w1: G satisfy { trivial_group_hom[G, H](w0 * w1) != trivial_group_hom[G, H](w0) * trivial_group_hom[G, H](w1) }","function[T0: Group, T1: Group](x0: T1) { T0.1 = trivial_group_hom[T1, T0](x0) }[H, G](w0 * w1)","function[T0: Group, T1: Group](x0: T1) { T0.1 = trivial_group_hom[T1, T0](x0) }[H, G](w1)"]}
 {"goal":"f.hom = g.hom","proof":[]}
 {"goal":"group_hom_ext","proof":["function[T0: Group, T1: Group](x0: GroupHom[T0, T1]) { GroupHom.new[T0, T1](x0.hom) = Option.some[GroupHom[T0, T1]](x0) }[G, H](f)","function[T0: Group, T1: Group](x0: GroupHom[T0, T1]) { GroupHom.new[T0, T1](x0.hom) = Option.some[GroupHom[T0, T1]](x0) }[G, H](g)","function[T0](x0: T0, x1: T0) { Option.some[T0](x0) != Option.some[T0](x1) or x0 = x1 }[GroupHom[G, H]](g, f)"]}
-{"goal":"group_hom_eq_hom","proof":["g != f"]}
-{"goal":"f.hom = g.hom","proof":["g != f"]}
-{"goal":"f.hom(a) = g.hom(a)","proof":["g != f"]}
-{"goal":"group_hom_eq_apply","proof":["g != f"]}
-{"goal":"group_hom_eq_transport_predicate","proof":["p(f)","g = f"]}
-{"goal":"group_hom_eq_transport_predicate_rev","proof":["p(g)","g = f"]}
-{"goal":"f.hom(a) = g.hom(a)","proof":["function(x0: G) { g.hom(x0) = f.hom(x0) }(a)"]}
-{"goal":"group_hom_eq_of_hom_eq","proof":["not forall(x0: G) { f.hom(x0) = g.hom(x0) } or g.hom != f.hom","let w0: G satisfy { f.hom(w0) != g.hom(w0) }","function(x0: G) { g.hom(x0) = f.hom(x0) }(w0)"]}
-{"goal":"group_hom_eq_of_apply_eq","proof":["let w0: G satisfy { f.hom(w0) != g.hom(w0) }","function(x0: G) { g.hom(x0) = f.hom(x0) }(w0)"]}
+{"goal":"group_hom_eq_hom","proof":[]}
+{"goal":"f.hom = g.hom","proof":[]}
+{"goal":"f.hom(a) = g.hom(a)","proof":[]}
+{"goal":"group_hom_eq_apply","proof":[]}
+{"goal":"group_hom_eq_transport_predicate","proof":[]}
+{"goal":"group_hom_eq_transport_predicate_rev","proof":[]}
+{"goal":"f.hom(a) = g.hom(a)","proof":[]}
+{"goal":"group_hom_eq_of_hom_eq","proof":["not forall(x0: G) { f.hom(x0) = g.hom(x0) } or g.hom != f.hom","let w0: G satisfy { f.hom(w0) != g.hom(w0) }"]}
+{"goal":"group_hom_eq_of_apply_eq","proof":["let w0: G satisfy { f.hom(w0) != g.hom(w0) }"]}
 {"goal":"is_group_hom[G, H](f.hom)","proof":["function[T0: Group, T1: Group](x0: GroupHom[T0, T1]) { is_group_hom[T0, T1](x0.hom) }[G, H](f)"]}
 {"goal":"group_hom_mul","proof":["function[T0: Group, T1: Group](x0: T0 -> T1) { forall(x1: T0, x2: T0) { x0(x1 * x2) = x0(x1) * x0(x2) } = is_group_hom[T0, T1](x0) }[G, H](f.hom)","function[T0, T1](x0: T0 -> T1, x1: (T0, T0) -> T0, x2: (T1, T1) -> T1) { forall(x3: T0, x4: T0) { x0(x1(x3, x4)) = x2(x0(x3), x0(x4)) } = lib(relation_transport).preserves_binary_op[T0, T1](x0, x1, x2) }[G, H](f.hom, G.mul, H.mul)","function[T0, T1](x0: T0 -> T1, x1: (T0, T0) -> T0, x2: (T1, T1) -> T1, x3: T0, x4: T0) { not lib(relation_transport).preserves_binary_op[T0, T1](x0, x1, x2) or x0(x1(x3, x4)) = x2(x0(x3), x0(x4)) }[G, H](f.hom, G.mul, H.mul, a, b)"]}
 {"goal":"G.1 * G.1 = G.1","proof":["function[T0: Monoid](x0: T0) { T0.1 * x0 = x0 }[G](G.1)"]}
@@ -74,8 +74,8 @@
 {"goal":"f.hom(a) * f.hom(a).pow(k) = f.hom(a).pow(k.suc)","proof":["function[T2: Monoid](x0: Nat, x1: Nat, x2: T2) { x0.suc != x1 or x2 * x2.pow(x0) = x2.pow(x1) }[H](k, k.suc, f.hom(a))"]}
 {"goal":"p(k.suc)","proof":["function(x0: Nat) { f.hom(a.pow(x0)) = f.hom(a).pow(x0) = p(x0) }(k.suc)"]}
 {"goal":"group_hom_pow","proof":["function(x0: Nat) { f.hom(a.pow(x0)) = f.hom(a).pow(x0) = p(x0) }(n)","function(x0: Nat -> Bool) { not forall(x1: Nat) { not x0(x1) or x0(x1.suc) } or not x0(Nat.0) or forall(x2: Nat) { x0(x2) } = true }(p)","function(x0: Nat) { not p(x0) or f.hom(a).pow(x0) = f.hom(a.pow(x0)) }(n)","function(x0: Nat -> Bool, x1: Nat) { not forall(x2: Nat) { not x0(x2) or x0(x2.suc) } or not x0(Nat.0) or x0(x1) }(p, n)","not p(n)","let w0: Nat satisfy { p(w0) and not p(w0.suc) }","function(x0: Nat) { not p(x0) or p(x0.suc) }(w0)"]}
-{"goal":"function_eq_transport_group_hom","proof":["g = f","is_group_hom[G, H](f)","not is_group_hom[G, H](f)"]}
-{"goal":"function_eq_transport_group_hom_rev","proof":["g = f","is_group_hom[G, H](g)","not is_group_hom[G, H](g)"]}
+{"goal":"function_eq_transport_group_hom","proof":[]}
+{"goal":"function_eq_transport_group_hom_rev","proof":[]}
 {"goal":"identity_fn(a * b) = a * b","proof":["function[T0, T1](x0: T0 -> T1, x1: T0) { compose[T0, T1, T1](identity_fn[T1], x0, x1) = x0(x1) }[G, G](a.mul, b)","function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[G, G, G](identity_fn[G], a.mul, b)"]}
 {"goal":"identity_fn(a) * identity_fn(b) = a * b","proof":["function[T0, T1](x0: T0 -> T1, x1: T0) { compose[T0, T0, T1](x0, identity_fn[T0], x1) = x0(x1) }[G, G](a.mul, b)","function[T0, T1](x0: T0 -> T1, x1: T0) { compose[T0, T0, T1](x0, identity_fn[T0], x1) = x0(x1) }[G, G -> G](G.mul, a)","function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[G, G, G -> G](G.mul, identity_fn[G], a)","function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[G, G, G](identity_fn(a).mul, identity_fn[G], b)"]}
 {"goal":"identity_fn_is_group_hom","proof":["function[T0: Group, T1: Group](x0: T0 -> T1) { forall(x1: T0, x2: T0) { x0(x1 * x2) = x0(x1) * x0(x2) } = is_group_hom[T0, T1](x0) }[G, G](identity_fn[G])","function[T0, T1](x0: T0 -> T1, x1: (T0, T0) -> T0, x2: (T1, T1) -> T1) { forall(x3: T0, x4: T0) { x0(x1(x3, x4)) = x2(x0(x3), x0(x4)) } = lib(relation_transport).preserves_binary_op[T0, T1](x0, x1, x2) }[G, G](identity_fn[G], G.mul, G.mul)","function[T0](x0: (T0, T0) -> T0) { lib(relation_transport).preserves_binary_op[T0, T0](identity_fn[T0], x0, x0) }[G](G.mul)"]}

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -77,7 +77,7 @@
     "real.triangular_sum": "233d44e2ede6c7b2278d8c071b84b79bf98cef0d4a608cd3e0df47d175121cfb",
     "relation": "be09d2c2e6cc9476149617d306955e6ff8c834c86eb8082b81b7a11d9a74fb2d",
     "relation_basic": "6c513f259da079c1bc6e85c8ffd11770e1b656603a9df252b0c48ab044e78da1",
-    "relation_transport": "e223e0bebaedd460a887eb145ce2de3fad5d307d8f029ff1648c4e3331e69927",
+    "relation_transport": "e16e0a8d3acb895814a3a760946559d5cffdb843797b854e2f568000e2ded575",
     "ring": "ca879591091e736df94f2fea9ad637a5a3b5f53fc9331105469a347d9727da4c",
     "semigroup": "fe447410f73ecf26812d523903d89bd4e8fc9f57abf4b6326c1d96b97efd0935",
     "semiring": "a9e2a52a901c480363ff641631c280bdbbf6fe964eda9fb83b22cd0d4eb5fcb5",

--- a/build/relation_transport.jsonl
+++ b/build/relation_transport.jsonl
@@ -1168,29 +1168,178 @@
 {"goal":"relation_pushforward_is_binary_congruence_of_bijection_eq","proof":[]}
 {"goal":"unary_op_pushforward[A, B](f, op_a) = op_b","proof":[]}
 {"goal":"op_b = unary_op_pushforward[A, B](f, op_a)","proof":[]}
-{"goal":"preserves_unary_op[A, B](f, op_a, unary_op_pushforward[A, B](f, op_a))","proof":["not is_bijection_fn[A, B](f)"]}
-{"goal":"preserves_unary_op[A, B](f, op_a, op_b)","proof":["not preserves_unary_op[A, B](f, op_a, unary_op_pushforward[A, B](f, op_a)) or unary_op_pushforward[A, B](f, op_a) != op_b","preserves_unary_op[A, B](f, op_a, unary_op_pushforward[A, B](f, op_a))","unary_op_pushforward[A, B](f, op_a) = op_b","unary_op_pushforward[A, B](f, op_a) != op_b"]}
-{"goal":"preserves_unary_op[A, B](f, op_a, op_b) = (op_b = unary_op_pushforward[A, B](f, op_a))","proof":["preserves_unary_op[A, B](f, op_a, op_b) or unary_op_pushforward[A, B](f, op_a) = op_b","not preserves_unary_op[A, B](f, op_a, op_b) or unary_op_pushforward[A, B](f, op_a) != op_b","preserves_unary_op[A, B](f, op_a, op_b)","unary_op_pushforward[A, B](f, op_a) != op_b","unary_op_pushforward[A, B](f, op_a) = op_b"]}
-{"goal":"preserves_unary_op_iff_unary_op_pushforward_eq_of_bijection","proof":["not is_bijection_fn[A, B](f)"]}
+{"goal":"preserves_unary_op[A, B](f, op_a, unary_op_pushforward[A, B](f, op_a))","proof":[]}
+{"goal":"preserves_unary_op[A, B](f, op_a, op_b)","proof":[]}
+{"goal":"preserves_unary_op[A, B](f, op_a, op_b) = (op_b = unary_op_pushforward[A, B](f, op_a))","proof":[]}
+{"goal":"preserves_unary_op_iff_unary_op_pushforward_eq_of_bijection","proof":[]}
 {"goal":"binary_op_pushforward[A, B](f, op_a) = op_b","proof":[]}
 {"goal":"op_b = binary_op_pushforward[A, B](f, op_a)","proof":[]}
-{"goal":"preserves_binary_op[A, B](f, op_a, binary_op_pushforward[A, B](f, op_a))","proof":["not is_bijection_fn[A, B](f)"]}
-{"goal":"preserves_binary_op[A, B](f, op_a, op_b)","proof":["not preserves_binary_op[A, B](f, op_a, binary_op_pushforward[A, B](f, op_a)) or binary_op_pushforward[A, B](f, op_a) != op_b","preserves_binary_op[A, B](f, op_a, binary_op_pushforward[A, B](f, op_a))","binary_op_pushforward[A, B](f, op_a) != op_b","binary_op_pushforward[A, B](f, op_a) = op_b"]}
-{"goal":"preserves_binary_op[A, B](f, op_a, op_b) = (op_b = binary_op_pushforward[A, B](f, op_a))","proof":["preserves_binary_op[A, B](f, op_a, op_b) or binary_op_pushforward[A, B](f, op_a) = op_b","not preserves_binary_op[A, B](f, op_a, op_b) or binary_op_pushforward[A, B](f, op_a) != op_b","preserves_binary_op[A, B](f, op_a, op_b)","binary_op_pushforward[A, B](f, op_a) != op_b","binary_op_pushforward[A, B](f, op_a) = op_b"]}
-{"goal":"preserves_binary_op_iff_binary_op_pushforward_eq_of_bijection","proof":["not is_bijection_fn[A, B](f)"]}
-{"goal":"unary_op_pushforward[A, B](f, op_a) = op_b","proof":["not preserves_unary_op[A, B](f, op_a, op_b) or not is_bijection_fn[A, B](f)","is_bijection_fn[A, B](f)","preserves_unary_op[A, B](f, op_a, op_b)","not preserves_unary_op[A, B](f, op_a, op_b)"]}
-{"goal":"respects_unary_op[B](relation_pushforward[A, B](f, r), unary_op_pushforward[A, B](f, op_a)) = respects_unary_op[A](r, op_a)","proof":["not is_bijection_fn[A, B](f)"]}
-{"goal":"respects_unary_op[B](relation_pushforward[A, B](f, r), op_b) = respects_unary_op[A](r, op_a)","proof":["unary_op_pushforward[A, B](f, op_a) = op_b"]}
-{"goal":"relation_pushforward_respects_unary_op_iff_of_bijection_eq","proof":["not preserves_unary_op[A, B](f, op_a, op_b) or not is_bijection_fn[A, B](f)","is_bijection_fn[A, B](f)","preserves_unary_op[A, B](f, op_a, op_b)","not preserves_unary_op[A, B](f, op_a, op_b)"]}
-{"goal":"binary_op_pushforward[A, B](f, op_a) = op_b","proof":["not preserves_binary_op[A, B](f, op_a, op_b) or not is_bijection_fn[A, B](f)","is_bijection_fn[A, B](f)","preserves_binary_op[A, B](f, op_a, op_b)","not preserves_binary_op[A, B](f, op_a, op_b)"]}
-{"goal":"respects_binary_op[B](relation_pushforward[A, B](f, r), binary_op_pushforward[A, B](f, op_a)) = respects_binary_op[A](r, op_a)","proof":["not is_bijection_fn[A, B](f)"]}
-{"goal":"respects_binary_op[B](relation_pushforward[A, B](f, r), op_b) = respects_binary_op[A](r, op_a)","proof":["binary_op_pushforward[A, B](f, op_a) = op_b"]}
-{"goal":"relation_pushforward_respects_binary_op_iff_of_bijection_eq","proof":["not preserves_binary_op[A, B](f, op_a, op_b) or not is_bijection_fn[A, B](f)","is_bijection_fn[A, B](f)","preserves_binary_op[A, B](f, op_a, op_b)","not preserves_binary_op[A, B](f, op_a, op_b)"]}
-{"goal":"unary_op_pushforward[A, B](f, op_a) = op_b","proof":["not preserves_unary_op[A, B](f, op_a, op_b) or not is_bijection_fn[A, B](f)","is_bijection_fn[A, B](f)","preserves_unary_op[A, B](f, op_a, op_b)","not preserves_unary_op[A, B](f, op_a, op_b)"]}
-{"goal":"is_unary_congruence[B](relation_pushforward[A, B](f, r), unary_op_pushforward[A, B](f, op_a)) = is_unary_congruence[A](r, op_a)","proof":["not is_bijection_fn[A, B](f)"]}
-{"goal":"is_unary_congruence[B](relation_pushforward[A, B](f, r), op_b) = is_unary_congruence[A](r, op_a)","proof":["unary_op_pushforward[A, B](f, op_a) = op_b"]}
-{"goal":"relation_pushforward_is_unary_congruence_iff_of_bijection_eq","proof":["not preserves_unary_op[A, B](f, op_a, op_b) or not is_bijection_fn[A, B](f)","is_bijection_fn[A, B](f)","preserves_unary_op[A, B](f, op_a, op_b)","not preserves_unary_op[A, B](f, op_a, op_b)"]}
-{"goal":"binary_op_pushforward[A, B](f, op_a) = op_b","proof":["not preserves_binary_op[A, B](f, op_a, op_b) or not is_bijection_fn[A, B](f)","is_bijection_fn[A, B](f)","preserves_binary_op[A, B](f, op_a, op_b)","not preserves_binary_op[A, B](f, op_a, op_b)"]}
-{"goal":"is_binary_congruence[B](relation_pushforward[A, B](f, r), binary_op_pushforward[A, B](f, op_a)) = is_binary_congruence[A](r, op_a)","proof":["not is_bijection_fn[A, B](f)"]}
-{"goal":"is_binary_congruence[B](relation_pushforward[A, B](f, r), op_b) = is_binary_congruence[A](r, op_a)","proof":["binary_op_pushforward[A, B](f, op_a) = op_b"]}
-{"goal":"relation_pushforward_is_binary_congruence_iff_of_bijection_eq","proof":["not preserves_binary_op[A, B](f, op_a, op_b) or not is_bijection_fn[A, B](f)","is_bijection_fn[A, B](f)","preserves_binary_op[A, B](f, op_a, op_b)","not preserves_binary_op[A, B](f, op_a, op_b)"]}
+{"goal":"preserves_binary_op[A, B](f, op_a, binary_op_pushforward[A, B](f, op_a))","proof":[]}
+{"goal":"preserves_binary_op[A, B](f, op_a, op_b)","proof":[]}
+{"goal":"preserves_binary_op[A, B](f, op_a, op_b) = (op_b = binary_op_pushforward[A, B](f, op_a))","proof":[]}
+{"goal":"preserves_binary_op_iff_binary_op_pushforward_eq_of_bijection","proof":[]}
+{"goal":"unary_op_pushforward[A, B](f, op_a) = op_b","proof":[]}
+{"goal":"respects_unary_op[B](relation_pushforward[A, B](f, r), unary_op_pushforward[A, B](f, op_a)) = respects_unary_op[A](r, op_a)","proof":[]}
+{"goal":"respects_unary_op[B](relation_pushforward[A, B](f, r), op_b) = respects_unary_op[A](r, op_a)","proof":[]}
+{"goal":"relation_pushforward_respects_unary_op_iff_of_bijection_eq","proof":[]}
+{"goal":"binary_op_pushforward[A, B](f, op_a) = op_b","proof":[]}
+{"goal":"respects_binary_op[B](relation_pushforward[A, B](f, r), binary_op_pushforward[A, B](f, op_a)) = respects_binary_op[A](r, op_a)","proof":[]}
+{"goal":"respects_binary_op[B](relation_pushforward[A, B](f, r), op_b) = respects_binary_op[A](r, op_a)","proof":[]}
+{"goal":"relation_pushforward_respects_binary_op_iff_of_bijection_eq","proof":[]}
+{"goal":"unary_op_pushforward[A, B](f, op_a) = op_b","proof":[]}
+{"goal":"is_unary_congruence[B](relation_pushforward[A, B](f, r), unary_op_pushforward[A, B](f, op_a)) = is_unary_congruence[A](r, op_a)","proof":[]}
+{"goal":"is_unary_congruence[B](relation_pushforward[A, B](f, r), op_b) = is_unary_congruence[A](r, op_a)","proof":[]}
+{"goal":"relation_pushforward_is_unary_congruence_iff_of_bijection_eq","proof":[]}
+{"goal":"binary_op_pushforward[A, B](f, op_a) = op_b","proof":[]}
+{"goal":"is_binary_congruence[B](relation_pushforward[A, B](f, r), binary_op_pushforward[A, B](f, op_a)) = is_binary_congruence[A](r, op_a)","proof":[]}
+{"goal":"is_binary_congruence[B](relation_pushforward[A, B](f, r), op_b) = is_binary_congruence[A](r, op_a)","proof":[]}
+{"goal":"relation_pushforward_is_binary_congruence_iff_of_bijection_eq","proof":[]}
+{"goal":"respects_add_eq_respects_binary_op","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.add) = respects_add[T0](x0) }[T](r)"]}
+{"goal":"add_congruence_eq_binary_congruence","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[T](r)"]}
+{"goal":"preserves_add_eq_preserves_binary_op","proof":["function[T0: Add, T1: Add](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.add, T1.add) = preserves_add[T0, T1](x0) }[A, B](f)"]}
+{"goal":"respects_add[T](r) = respects_binary_op[T](r, T.add)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.add) = respects_add[T0](x0) }[T](r)"]}
+{"goal":"r(x1 + x2, y1 + y2)","proof":[]}
+{"goal":"r(x1 + x2, y1 + y2)","proof":[]}
+{"goal":"respects_add_step","proof":[]}
+{"goal":"is_add_congruence[T](r) = is_binary_congruence[T](r, T.add)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[T](r)"]}
+{"goal":"r(x1 + x2, y1 + y2)","proof":[]}
+{"goal":"r(x1 + x2, y1 + y2)","proof":[]}
+{"goal":"add_congruence_step","proof":[]}
+{"goal":"is_add_congruence[T](r) = is_binary_congruence[T](r, T.add)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[T](r)"]}
+{"goal":"is_equivalence[T](r)","proof":[]}
+{"goal":"add_congruence_is_equivalence","proof":[]}
+{"goal":"is_add_congruence[T](r) = is_binary_congruence[T](r, T.add)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[T](r)"]}
+{"goal":"respects_binary_op[T](r, T.add)","proof":[]}
+{"goal":"respects_add[T](r)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.add) = respects_add[T0](x0) }[T](r)"]}
+{"goal":"add_congruence_respects_add","proof":[]}
+{"goal":"respects_binary_op[T](eq_relation[T], T.add)","proof":[]}
+{"goal":"respects_add[T](eq_relation[T])","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.add) = respects_add[T0](x0) }[T](eq_relation[T])"]}
+{"goal":"eq_relation_respects_add","proof":[]}
+{"goal":"is_binary_congruence[T](eq_relation[T], T.add)","proof":[]}
+{"goal":"is_add_congruence[T](eq_relation[T])","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[T](eq_relation[T])"]}
+{"goal":"eq_relation_is_add_congruence","proof":[]}
+{"goal":"preserves_add[A, B](f) = preserves_binary_op[A, B](f, A.add, B.add)","proof":["function[T0: Add, T1: Add](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.add, T1.add) = preserves_add[T0, T1](x0) }[A, B](f)"]}
+{"goal":"f(x + y) = f(x) + f(y)","proof":[]}
+{"goal":"f(x + y) = f(x) + f(y)","proof":[]}
+{"goal":"preserves_add_step","proof":[]}
+{"goal":"respects_add[B](r) = respects_binary_op[B](r, B.add)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.add) = respects_add[T0](x0) }[B](r)"]}
+{"goal":"preserves_add[A, B](f) = preserves_binary_op[A, B](f, A.add, B.add)","proof":["function[T0: Add, T1: Add](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.add, T1.add) = preserves_add[T0, T1](x0) }[A, B](f)"]}
+{"goal":"respects_binary_op[A](relation_pullback[A, B](f, r), A.add)","proof":[]}
+{"goal":"respects_add[A](relation_pullback[A, B](f, r))","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.add) = respects_add[T0](x0) }[A](relation_pullback[A, B](f, r))"]}
+{"goal":"relation_pullback_respects_add_of_preserves_add","proof":[]}
+{"goal":"is_add_congruence[B](r) = is_binary_congruence[B](r, B.add)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[B](r)"]}
+{"goal":"preserves_add[A, B](f) = preserves_binary_op[A, B](f, A.add, B.add)","proof":["function[T0: Add, T1: Add](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.add, T1.add) = preserves_add[T0, T1](x0) }[A, B](f)"]}
+{"goal":"is_binary_congruence[A](relation_pullback[A, B](f, r), A.add)","proof":[]}
+{"goal":"is_add_congruence[A](relation_pullback[A, B](f, r))","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[A](relation_pullback[A, B](f, r))"]}
+{"goal":"relation_pullback_is_add_congruence_of_preserves_add","proof":[]}
+{"goal":"preserves_add[A, B](f) = preserves_binary_op[A, B](f, A.add, B.add)","proof":["function[T0: Add, T1: Add](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.add, T1.add) = preserves_add[T0, T1](x0) }[A, B](f)"]}
+{"goal":"respects_binary_op[A](relation_pullback[A, B](f, r), A.add) = respects_binary_op[B](r, B.add)","proof":[]}
+{"goal":"respects_add[A](relation_pullback[A, B](f, r)) = respects_add[B](r)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.add) = respects_add[T0](x0) }[B](r)","function[T0: Add](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.add) = respects_add[T0](x0) }[A](relation_pullback[A, B](f, r))"]}
+{"goal":"relation_pullback_respects_add_iff_of_surjective","proof":[]}
+{"goal":"preserves_add[A, B](f) = preserves_binary_op[A, B](f, A.add, B.add)","proof":["function[T0: Add, T1: Add](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.add, T1.add) = preserves_add[T0, T1](x0) }[A, B](f)"]}
+{"goal":"is_binary_congruence[A](relation_pullback[A, B](f, r), A.add) = is_binary_congruence[B](r, B.add)","proof":[]}
+{"goal":"is_add_congruence[A](relation_pullback[A, B](f, r)) = is_add_congruence[B](r)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[B](r)","function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[A](relation_pullback[A, B](f, r))"]}
+{"goal":"relation_pullback_is_add_congruence_iff_of_surjective","proof":[]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = u1 and f(k1) = v1 and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x1) = u1 and f(k0) = v1 and r(x1, k0) }","proof":[]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = u2 and f(k1) = v2 and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x2) = u2 and f(k0) = v2 and r(x2, k0) }","proof":[]}
+{"goal":"r(x1 + x2, y1 + y2)","proof":[]}
+{"goal":"f(x1 + x2) = f(x1) + f(x2)","proof":[]}
+{"goal":"f(y1 + y2) = f(y1) + f(y2)","proof":[]}
+{"goal":"f(x1 + x2) = u1 + u2","proof":[]}
+{"goal":"f(y1 + y2) = v1 + v2","proof":[]}
+{"goal":"relation_pushforward[A, B](f, r, u1 + u2, v1 + v2)","proof":[]}
+{"goal":"respects_add[B](relation_pushforward[A, B](f, r)) = respects_binary_op[B](relation_pushforward[A, B](f, r), B.add)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.add) = respects_add[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"respects_binary_op[B](relation_pushforward[A, B](f, r), B.add) = forall(x0: B, x1: B, x2: B, x3: B) { relation_pushforward[A, B](f, r, x0, x1) and relation_pushforward[A, B](f, r, x2, x3) implies relation_pushforward[A, B](f, r, x0 + x2, x1 + x3) }","proof":["function[T0](x0: (T0, T0) -> Bool, x1: (T0, T0) -> T0) { forall(x2: T0, x3: T0, x4: T0, x5: T0) { not x0(x2, x3) or not x0(x4, x5) or x0(x1(x2, x4), x1(x3, x5)) } = respects_binary_op[T0](x0, x1) }[B](relation_pushforward[A, B](f, r), B.add)"]}
+{"goal":"respects_add[B](relation_pushforward[A, B](f, r))","proof":["not respects_binary_op[B](relation_pushforward[A, B](f, r), B.add)","let w0: B satisfy { exists(k0: B, k1: B, k2: B) { relation_pushforward[A, B](f, r, w0, k0) and relation_pushforward[A, B](f, r, k1, k2) and not relation_pushforward[A, B](f, r, w0 + k1, k0 + k2) } }","let w1: B satisfy { exists(k3: B, k4: B) { relation_pushforward[A, B](f, r, w0, w1) and relation_pushforward[A, B](f, r, k3, k4) and not relation_pushforward[A, B](f, r, w0 + k3, w1 + k4) } }","let w2: B satisfy { exists(k5: B) { relation_pushforward[A, B](f, r, w0, w1) and relation_pushforward[A, B](f, r, w2, k5) and not relation_pushforward[A, B](f, r, w0 + w2, w1 + k5) } }","let w3: B satisfy { relation_pushforward[A, B](f, r, w0, w1) and relation_pushforward[A, B](f, r, w2, w3) and not relation_pushforward[A, B](f, r, w0 + w2, w1 + w3) }","function(x0: B, x1: B, x2: B, x3: B) { not relation_pushforward[A, B](f, r, x0, x1) or not relation_pushforward[A, B](f, r, x2, x3) or relation_pushforward[A, B](f, r, x0 + x2, x1 + x3) }(w0, w1, w2, w3)"]}
+{"goal":"relation_pushforward_respects_add_of_bijection","proof":[]}
+{"goal":"is_add_congruence[A](r) = is_binary_congruence[A](r, A.add)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[A](r)"]}
+{"goal":"is_equivalence[A](r)","proof":[]}
+{"goal":"is_equivalence[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"respects_add[A](r)","proof":[]}
+{"goal":"respects_add[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"respects_add[B](relation_pushforward[A, B](f, r)) = respects_binary_op[B](relation_pushforward[A, B](f, r), B.add)","proof":["function[T0: Add](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.add) = respects_add[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"is_add_congruence[B](relation_pushforward[A, B](f, r))","proof":["function[T0](x0: (T0, T0) -> Bool, x1: (T0, T0) -> T0) { (is_equivalence[T0](x0) and respects_binary_op[T0](x0, x1)) = is_binary_congruence[T0](x0, x1) }[B](relation_pushforward[A, B](f, r), B.add)","function[T0, T1](x0: T0 -> T1, x1: T0) { compose[T0, T1, T1](identity_fn[T1], x0, x1) = x0(x1) }[Bool, Bool -> Bool]((and), is_bijection_fn[A, B](f))","function[T0, T1](x0: T0 -> T1, x1: T0) { compose[T0, T1, T1](identity_fn[T1], x0, x1) = x0(x1) }[Bool, Bool -> Bool]((and), is_bijection_fn[A, B](f) and preserves_add[A, B](f))","function[T0: Add](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.add) = is_add_congruence[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"relation_pushforward_is_add_congruence_of_bijection","proof":[]}
+{"goal":"respects_mul_eq_respects_binary_op","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.mul) = respects_mul[T0](x0) }[T](r)"]}
+{"goal":"mul_congruence_eq_binary_congruence","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[T](r)"]}
+{"goal":"preserves_mul_eq_preserves_binary_op","proof":["function[T0: Mul, T1: Mul](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.mul, T1.mul) = preserves_mul[T0, T1](x0) }[A, B](f)"]}
+{"goal":"respects_mul[T](r) = respects_binary_op[T](r, T.mul)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.mul) = respects_mul[T0](x0) }[T](r)"]}
+{"goal":"r(x1 * x2, y1 * y2)","proof":[]}
+{"goal":"r(x1 * x2, y1 * y2)","proof":[]}
+{"goal":"respects_mul_step","proof":[]}
+{"goal":"is_mul_congruence[T](r) = is_binary_congruence[T](r, T.mul)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[T](r)"]}
+{"goal":"r(x1 * x2, y1 * y2)","proof":[]}
+{"goal":"r(x1 * x2, y1 * y2)","proof":[]}
+{"goal":"mul_congruence_step","proof":[]}
+{"goal":"is_mul_congruence[T](r) = is_binary_congruence[T](r, T.mul)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[T](r)"]}
+{"goal":"is_equivalence[T](r)","proof":[]}
+{"goal":"mul_congruence_is_equivalence","proof":[]}
+{"goal":"is_mul_congruence[T](r) = is_binary_congruence[T](r, T.mul)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[T](r)"]}
+{"goal":"respects_binary_op[T](r, T.mul)","proof":[]}
+{"goal":"respects_mul[T](r)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.mul) = respects_mul[T0](x0) }[T](r)"]}
+{"goal":"mul_congruence_respects_mul","proof":[]}
+{"goal":"respects_binary_op[T](eq_relation[T], T.mul)","proof":[]}
+{"goal":"respects_mul[T](eq_relation[T])","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.mul) = respects_mul[T0](x0) }[T](eq_relation[T])"]}
+{"goal":"eq_relation_respects_mul","proof":[]}
+{"goal":"is_binary_congruence[T](eq_relation[T], T.mul)","proof":[]}
+{"goal":"is_mul_congruence[T](eq_relation[T])","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[T](eq_relation[T])"]}
+{"goal":"eq_relation_is_mul_congruence","proof":[]}
+{"goal":"preserves_mul[A, B](f) = preserves_binary_op[A, B](f, A.mul, B.mul)","proof":["function[T0: Mul, T1: Mul](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.mul, T1.mul) = preserves_mul[T0, T1](x0) }[A, B](f)"]}
+{"goal":"f(x * y) = f(x) * f(y)","proof":[]}
+{"goal":"f(x * y) = f(x) * f(y)","proof":[]}
+{"goal":"preserves_mul_step","proof":[]}
+{"goal":"respects_mul[B](r) = respects_binary_op[B](r, B.mul)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.mul) = respects_mul[T0](x0) }[B](r)"]}
+{"goal":"preserves_mul[A, B](f) = preserves_binary_op[A, B](f, A.mul, B.mul)","proof":["function[T0: Mul, T1: Mul](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.mul, T1.mul) = preserves_mul[T0, T1](x0) }[A, B](f)"]}
+{"goal":"respects_binary_op[A](relation_pullback[A, B](f, r), A.mul)","proof":[]}
+{"goal":"respects_mul[A](relation_pullback[A, B](f, r))","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.mul) = respects_mul[T0](x0) }[A](relation_pullback[A, B](f, r))"]}
+{"goal":"relation_pullback_respects_mul_of_preserves_mul","proof":[]}
+{"goal":"is_mul_congruence[B](r) = is_binary_congruence[B](r, B.mul)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[B](r)"]}
+{"goal":"preserves_mul[A, B](f) = preserves_binary_op[A, B](f, A.mul, B.mul)","proof":["function[T0: Mul, T1: Mul](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.mul, T1.mul) = preserves_mul[T0, T1](x0) }[A, B](f)"]}
+{"goal":"is_binary_congruence[A](relation_pullback[A, B](f, r), A.mul)","proof":[]}
+{"goal":"is_mul_congruence[A](relation_pullback[A, B](f, r))","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[A](relation_pullback[A, B](f, r))"]}
+{"goal":"relation_pullback_is_mul_congruence_of_preserves_mul","proof":[]}
+{"goal":"preserves_mul[A, B](f) = preserves_binary_op[A, B](f, A.mul, B.mul)","proof":["function[T0: Mul, T1: Mul](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.mul, T1.mul) = preserves_mul[T0, T1](x0) }[A, B](f)"]}
+{"goal":"respects_binary_op[A](relation_pullback[A, B](f, r), A.mul) = respects_binary_op[B](r, B.mul)","proof":[]}
+{"goal":"respects_mul[A](relation_pullback[A, B](f, r)) = respects_mul[B](r)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.mul) = respects_mul[T0](x0) }[B](r)","function[T0: Mul](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.mul) = respects_mul[T0](x0) }[A](relation_pullback[A, B](f, r))"]}
+{"goal":"relation_pullback_respects_mul_iff_of_surjective","proof":[]}
+{"goal":"preserves_mul[A, B](f) = preserves_binary_op[A, B](f, A.mul, B.mul)","proof":["function[T0: Mul, T1: Mul](x0: T0 -> T1) { preserves_binary_op[T0, T1](x0, T0.mul, T1.mul) = preserves_mul[T0, T1](x0) }[A, B](f)"]}
+{"goal":"is_binary_congruence[A](relation_pullback[A, B](f, r), A.mul) = is_binary_congruence[B](r, B.mul)","proof":[]}
+{"goal":"is_mul_congruence[A](relation_pullback[A, B](f, r)) = is_mul_congruence[B](r)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[B](r)","function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[A](relation_pullback[A, B](f, r))"]}
+{"goal":"relation_pullback_is_mul_congruence_iff_of_surjective","proof":[]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = u1 and f(k1) = v1 and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x1) = u1 and f(k0) = v1 and r(x1, k0) }","proof":[]}
+{"goal":"exists(k0: A) { exists(k1: A) { f(k0) = u2 and f(k1) = v2 and r(k0, k1) } }","proof":[]}
+{"goal":"exists(k0: A) { f(x2) = u2 and f(k0) = v2 and r(x2, k0) }","proof":[]}
+{"goal":"r(x1 * x2, y1 * y2)","proof":[]}
+{"goal":"f(x1 * x2) = f(x1) * f(x2)","proof":[]}
+{"goal":"f(y1 * y2) = f(y1) * f(y2)","proof":[]}
+{"goal":"f(x1 * x2) = u1 * u2","proof":[]}
+{"goal":"f(y1 * y2) = v1 * v2","proof":[]}
+{"goal":"relation_pushforward[A, B](f, r, u1 * u2, v1 * v2)","proof":[]}
+{"goal":"respects_mul[B](relation_pushforward[A, B](f, r)) = respects_binary_op[B](relation_pushforward[A, B](f, r), B.mul)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.mul) = respects_mul[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"respects_binary_op[B](relation_pushforward[A, B](f, r), B.mul) = forall(x0: B, x1: B, x2: B, x3: B) { relation_pushforward[A, B](f, r, x0, x1) and relation_pushforward[A, B](f, r, x2, x3) implies relation_pushforward[A, B](f, r, x0 * x2, x1 * x3) }","proof":["function[T0](x0: (T0, T0) -> Bool, x1: (T0, T0) -> T0) { forall(x2: T0, x3: T0, x4: T0, x5: T0) { not x0(x2, x3) or not x0(x4, x5) or x0(x1(x2, x4), x1(x3, x5)) } = respects_binary_op[T0](x0, x1) }[B](relation_pushforward[A, B](f, r), B.mul)"]}
+{"goal":"respects_mul[B](relation_pushforward[A, B](f, r))","proof":["not respects_binary_op[B](relation_pushforward[A, B](f, r), B.mul)","let w0: B satisfy { exists(k0: B, k1: B, k2: B) { relation_pushforward[A, B](f, r, w0, k0) and relation_pushforward[A, B](f, r, k1, k2) and not relation_pushforward[A, B](f, r, w0 * k1, k0 * k2) } }","let w1: B satisfy { exists(k3: B, k4: B) { relation_pushforward[A, B](f, r, w0, w1) and relation_pushforward[A, B](f, r, k3, k4) and not relation_pushforward[A, B](f, r, w0 * k3, w1 * k4) } }","let w2: B satisfy { exists(k5: B) { relation_pushforward[A, B](f, r, w0, w1) and relation_pushforward[A, B](f, r, w2, k5) and not relation_pushforward[A, B](f, r, w0 * w2, w1 * k5) } }","let w3: B satisfy { relation_pushforward[A, B](f, r, w0, w1) and relation_pushforward[A, B](f, r, w2, w3) and not relation_pushforward[A, B](f, r, w0 * w2, w1 * w3) }","function(x0: B, x1: B, x2: B, x3: B) { not relation_pushforward[A, B](f, r, x0, x1) or not relation_pushforward[A, B](f, r, x2, x3) or relation_pushforward[A, B](f, r, x0 * x2, x1 * x3) }(w0, w1, w2, w3)"]}
+{"goal":"relation_pushforward_respects_mul_of_bijection","proof":[]}
+{"goal":"is_mul_congruence[A](r) = is_binary_congruence[A](r, A.mul)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[A](r)"]}
+{"goal":"is_equivalence[A](r)","proof":[]}
+{"goal":"is_equivalence[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"respects_mul[A](r)","proof":[]}
+{"goal":"respects_mul[B](relation_pushforward[A, B](f, r))","proof":[]}
+{"goal":"respects_mul[B](relation_pushforward[A, B](f, r)) = respects_binary_op[B](relation_pushforward[A, B](f, r), B.mul)","proof":["function[T0: Mul](x0: (T0, T0) -> Bool) { respects_binary_op[T0](x0, T0.mul) = respects_mul[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"is_mul_congruence[B](relation_pushforward[A, B](f, r))","proof":["function[T0](x0: (T0, T0) -> Bool, x1: (T0, T0) -> T0) { (is_equivalence[T0](x0) and respects_binary_op[T0](x0, x1)) = is_binary_congruence[T0](x0, x1) }[B](relation_pushforward[A, B](f, r), B.mul)","function[T0, T1](x0: T0 -> T1, x1: T0) { compose[T0, T1, T1](identity_fn[T1], x0, x1) = x0(x1) }[Bool, Bool -> Bool]((and), is_bijection_fn[A, B](f))","function[T0, T1](x0: T0 -> T1, x1: T0) { compose[T0, T1, T1](identity_fn[T1], x0, x1) = x0(x1) }[Bool, Bool -> Bool]((and), is_bijection_fn[A, B](f) and preserves_mul[A, B](f))","function[T0: Mul](x0: (T0, T0) -> Bool) { is_binary_congruence[T0](x0, T0.mul) = is_mul_congruence[T0](x0) }[B](relation_pushforward[A, B](f, r))"]}
+{"goal":"relation_pushforward_is_mul_congruence_of_bijection","proof":[]}
+{"goal":"preserves_lte_eq_respects_equivalence","proof":["function[T0: LTE, T1: LTE](x0: T0 -> T1) { respects_equivalence[T0, T1](x0, T0.lte, T1.lte) = preserves_lte[T0, T1](x0) }[A, B](f)"]}
+{"goal":"preserves_lte[A, B](f) = respects_equivalence[A, B](f, A.lte, B.lte)","proof":["function[T0: LTE, T1: LTE](x0: T0 -> T1) { respects_equivalence[T0, T1](x0, T0.lte, T1.lte) = preserves_lte[T0, T1](x0) }[A, B](f)"]}
+{"goal":"respects_equivalence[A, B](f, A.lte, B.lte) = forall(x0: A, x1: A) { x0 <= x1 implies f(x0) <= f(x1) }","proof":["function[T0, T2](x0: (T0, T0) -> Bool, x1: (T2, T2) -> Bool, x2: T0 -> T2) { forall(x3: T0, x4: T0) { not x0(x3, x4) or x1(x2(x3), x2(x4)) } = respects_equivalence[T0, T2](x2, x0, x1) }[A, B](A.lte, B.lte, f)"]}
+{"goal":"f(x) <= f(y)","proof":["x <= y","preserves_lte[A, B](f)","not respects_equivalence[A, B](f, A.lte, B.lte) or forall(x0: A, x1: A) { not x0 <= x1 or f(x0) <= f(x1) } = true","respects_equivalence[A, B](f, A.lte, B.lte)","function(x0: A) { forall(x1: A) { not x0 <= x1 or f(x0) <= f(x1) } = true }(x)","function(x0: A, x1: A) { not (x0 <= x1 and not f(x0) <= f(x1)) }(x, y)"]}
+{"goal":"preserves_lte_step","proof":[]}
+{"goal":"respects_equivalence[A, B](f, relation_pullback[A, B](f, B.lte), B.lte)","proof":[]}
+{"goal":"function_respects_lte_pullback","proof":[]}
+{"goal":"is_reflexive[A](relation_pullback[A, B](f, B.lte)) and is_transitive[A](relation_pullback[A, B](f, B.lte)) and is_antisymmetric[A](relation_pullback[A, B](f, B.lte))","proof":[]}
+{"goal":"relation_pullback_lte_is_reflexive_transitive_antisymmetric_of_injective","proof":[]}
+{"goal":"(is_reflexive[A](relation_pullback[A, B](f, B.lte)) and is_transitive[A](relation_pullback[A, B](f, B.lte)) and is_antisymmetric[A](relation_pullback[A, B](f, B.lte))) = (is_reflexive[B](B.lte) and is_transitive[B](B.lte) and is_antisymmetric[B](B.lte))","proof":[]}
+{"goal":"relation_pullback_lte_is_reflexive_transitive_antisymmetric_iff_of_bijection","proof":[]}
+{"goal":"is_reflexive[B](relation_pushforward[A, B](f, A.lte)) and is_transitive[B](relation_pushforward[A, B](f, A.lte)) and is_antisymmetric[B](relation_pushforward[A, B](f, A.lte))","proof":[]}
+{"goal":"relation_pushforward_lte_is_reflexive_transitive_antisymmetric_of_bijection","proof":[]}

--- a/build/set.jsonl
+++ b/build/set.jsonl
@@ -22,15 +22,15 @@
 {"goal":"singleton_set_is_singleton","proof":["function[T0](x0: T0, x1: Set[T0]) { Set.singleton[T0](x0) != x1 or x1.is_singleton }[K](a, Set.singleton(a))"]}
 {"goal":"a.contains = b.contains","proof":[]}
 {"goal":"set_ext","proof":["function[T0](x0: Set[T0]) { Set.new[T0](x0.contains) = x0 }[K](a)","function[T0](x0: Set[T0]) { Set.new[T0](x0.contains) = x0 }[K](b)"]}
-{"goal":"set_eq_contains","proof":["b != a"]}
-{"goal":"a.contains = b.contains","proof":["b != a"]}
+{"goal":"set_eq_contains","proof":[]}
+{"goal":"a.contains = b.contains","proof":[]}
 {"goal":"a.contains(x) = b.contains(x)","proof":[]}
-{"goal":"set_eq_contains_at","proof":["b != a"]}
-{"goal":"set_eq_transport_predicate","proof":["p(a)","b = a"]}
-{"goal":"set_eq_transport_predicate_rev","proof":["p(b)","b = a"]}
-{"goal":"a.contains(x) = b.contains(x)","proof":["function(x0: K) { x0 ∈ b = x0 ∈ a }(x)"]}
-{"goal":"set_eq_of_contains_eq","proof":["function[T0](x0: Set[T0]) { Set.new[T0](x0.contains) = x0 }[K](a)","function[T0](x0: Set[T0]) { Set.new[T0](x0.contains) = x0 }[K](b)","b.contains = a.contains"]}
-{"goal":"set_eq_of_contains_at_eq","proof":["let w0: K satisfy { w0 ∈ a != w0 ∈ b }","function(x0: K) { x0 ∈ b = x0 ∈ a }(w0)"]}
+{"goal":"set_eq_contains_at","proof":[]}
+{"goal":"set_eq_transport_predicate","proof":[]}
+{"goal":"set_eq_transport_predicate_rev","proof":[]}
+{"goal":"a.contains(x) = b.contains(x)","proof":[]}
+{"goal":"set_eq_of_contains_eq","proof":["function[T0](x0: Set[T0]) { Set.new[T0](x0.contains) = x0 }[K](a)","function[T0](x0: Set[T0]) { Set.new[T0](x0.contains) = x0 }[K](b)"]}
+{"goal":"set_eq_of_contains_at_eq","proof":["let w0: K satisfy { w0 ∈ a != w0 ∈ b }"]}
 {"goal":"false","proof":["function[T0](x0: Set[T0]) { forall(x1: T0) { not x1 ∈ x0 } = x0.is_empty }[K](s)","function[T0](x0: Set[T0]) { not x0.is_empty or forall(x1: T0) { not x1 ∈ x0 } = true }[K](s)","function[T0](x0: Set[T0], x1: T0) { not x0.is_empty or not x1 ∈ x0 }[K](s, x)"]}
 {"goal":"s.contains(x) = Set.empty_set[K].contains(x)","proof":[]}
 {"goal":"set_eq_empty_of_is_empty","proof":["function[T0](x0: Set[T0]) { forall(x1: T0) { not x1 ∈ x0 } = x0.is_empty }[K](s)","not forall(x0: K) { x0 ∈ s = x0 ∈ Set.empty_set[K] } or not s.is_empty","let w0: K satisfy { w0 ∈ s != w0 ∈ Set.empty_set[K] }","function[T0](x0: T0) { not x0 ∈ Set.empty_set[T0] }[K](w0)","w0 ∈ Set.empty_set[K] or w0 ∈ s","w0 ∈ s","function[T0](x0: Set[T0]) { not x0.is_empty or forall(x1: T0) { not x1 ∈ x0 } = true }[K](s)","function[T0](x0: Set[T0], x1: T0) { not x0.is_empty or not x1 ∈ x0 }[K](s, w0)"]}
@@ -248,7 +248,7 @@
 {"goal":"nat_lt_set(bound.suc).contains(n)","proof":[]}
 {"goal":"nat_lt_set_subset_suc","proof":["function[T0](x0: Set[T0], x1: Set[T0]) { forall(x2: T0) { not x2 ∈ x0 or x2 ∈ x1 } = x0 ⊂ x1 }[Nat](nat_lt_set(bound), nat_lt_set(bound.suc))","let w0: Nat satisfy { w0 ∈ nat_lt_set(bound) and not w0 ∈ nat_lt_set(bound.suc) }","function(x0: Nat) { not x0 ∈ nat_lt_set(bound) or x0 ∈ nat_lt_set(bound.suc) }(w0)"]}
 {"goal":"b.contains(x) implies a.contains(x)","proof":["function[T0](x0: Set[T0], x1: Set[T0], x2: T0) { not x0 ⊂ x1 or not x2 ∈ x0 or x2 ∈ x1 }[K](b, a, x)"]}
-{"goal":"a.contains(x) = b.contains(x)","proof":["function[T0](x0: Set[T0], x1: Set[T0], x2: T0) { not x0 ⊂ x1 or not x2 ∈ x0 or x2 ∈ x1 }[K](a, b, x)","x ∈ b or x ∈ a","x ∈ a","not x ∈ b","a ⊂ b","function(x0: Set[K]) { not a ⊂ x0 or x ∈ x0 }(b)"]}
+{"goal":"a.contains(x) = b.contains(x)","proof":["function[T0](x0: Set[T0], x1: Set[T0], x2: T0) { not x0 ⊂ x1 or not x2 ∈ x0 or x2 ∈ x1 }[K](a, b, x)"]}
 {"goal":"double_inclusion","proof":["b.contains = a.contains","function[T0](x0: Set[T0]) { Set.new[T0](x0.contains) = x0 }[K](a)","function[T0](x0: Set[T0]) { Set.new[T0](x0.contains) = x0 }[K](b)"]}
 {"goal":"subset_antisymm","proof":[]}
 {"goal":"a.subset(b) and b.subset(a)","proof":["function[T0](x0: Set[T0], x1: Set[T0]) { x0 ⊃ x1 = x1 ⊂ x0 }[K](b, a)","function[T0](x0: Set[T0], x1: Set[T0]) { x0 ⊃ x1 = x1 ⊂ x0 }[K](a, b)"]}

--- a/projects/translate-mathlib/foundations/transport-across-equality/todo.md
+++ b/projects/translate-mathlib/foundations/transport-across-equality/todo.md
@@ -2,10 +2,9 @@
 
 Goal: support moving data and theorems across definitional boundaries in a controlled way.
 
-- [ ] Lift transported unary and binary operation lemmas to bundled algebraic structures
 - [ ] Add coercion-friendly equivalence wrappers where they reduce proof friction
 - [ ] Extend subobject transport from set and finite-set images to quotient-related data
-- [ ] Add ordered-structure transport wrappers on top of relation pushforward and pullback
+- [ ] Extend ordered-structure transport wrappers beyond bundled less-than-or-equal relation facts
 - [ ] Identify recurring transport pain points in current files and record them
 - [ ] Refactor one small existing development to use the shared transport API
 - [ ] Investigate type-level transport lemmas if Acorn exposes equality of types

--- a/src/relation_transport.ac
+++ b/src/relation_transport.ac
@@ -4,6 +4,9 @@ from functions import Inhabited, compose, identity_fn, inverse_fn, inverse_fn_ap
     inverse_fn_apply_image_of_bijection, predicate_extensionality, binary_function_extensionality,
     function_extensionality, is_injective_fn, is_surjective_fn, is_bijection_fn, bijection_fn_is_injective,
     bijection_fn_is_surjective, injective_fn_eq, surjective_fn_has_preimage
+from add import Add
+from mul import Mul
+from lte import LTE
 from relation_basic import eq_relation, is_reflexive, is_irreflexive, is_symmetric, is_asymmetric, is_transitive, is_total, is_antisymmetric, is_equivalence, is_partial_equivalence, relation_intersection, relation_subset, relation_subset_refl, relation_subset_step, relation_subset_trans, relation_converse, relation_reflexive_closure, relation_symmetric_closure, eq_relation_is_equivalence, relation_intersection_is_equivalence, relation_converse_is_equivalence, equivalence_is_reflexive, equivalence_is_symmetric, equivalence_is_transitive, partial_equivalence_is_symmetric, partial_equivalence_is_transitive, reflexive_self, symmetric_flip, transitive_step, antisymmetric_eq
 
 /// The pullback of a homogeneous relation along a function.
@@ -4322,5 +4325,537 @@ theorem relation_pushforward_is_binary_congruence_iff_of_bijection_eq[A: Inhabit
         relation_pushforward_is_binary_congruence_iff_of_bijection(f, r, op_a)
         is_binary_congruence(relation_pushforward(f, r), binary_op_pushforward(f, op_a)) = is_binary_congruence(r, op_a)
         is_binary_congruence(relation_pushforward(f, r), op_b) = is_binary_congruence(r, op_a)
+    }
+}
+
+/// True if a relation is compatible with the addition operation.
+define respects_add[T: Add](r: (T, T) -> Bool) -> Bool {
+    respects_binary_op(r, T.add)
+}
+
+/// True if a relation is an equivalence relation compatible with addition.
+define is_add_congruence[T: Add](r: (T, T) -> Bool) -> Bool {
+    is_binary_congruence(r, T.add)
+}
+
+/// True if a function preserves addition.
+define preserves_add[A: Add, B: Add](f: A -> B) -> Bool {
+    preserves_binary_op(f, A.add, B.add)
+}
+
+/// Additive compatibility is binary-operation compatibility for addition.
+theorem respects_add_eq_respects_binary_op[T: Add](r: (T, T) -> Bool) {
+    respects_add(r) = respects_binary_op(r, T.add)
+}
+
+/// Additive congruence is binary congruence for addition.
+theorem add_congruence_eq_binary_congruence[T: Add](r: (T, T) -> Bool) {
+    is_add_congruence(r) = is_binary_congruence(r, T.add)
+}
+
+/// Additive preservation is binary-operation preservation for addition.
+theorem preserves_add_eq_preserves_binary_op[A: Add, B: Add](f: A -> B) {
+    preserves_add(f) = preserves_binary_op(f, A.add, B.add)
+}
+
+/// An additive-compatible relation may be applied to related summands.
+theorem respects_add_step[T: Add](r: (T, T) -> Bool, x1: T, y1: T, x2: T, y2: T) {
+    respects_add(r) and r(x1, y1) and r(x2, y2) implies r(x1 + x2, y1 + y2)
+} by {
+    if respects_add(r) and r(x1, y1) and r(x2, y2) {
+        respects_add(r) = respects_binary_op(r, T.add)
+        respects_binary_op_step(r, T.add, x1, y1, x2, y2)
+        r(T.add(x1, x2), T.add(y1, y2))
+        r(x1 + x2, y1 + y2)
+    }
+}
+
+/// An additive congruence may be applied to related summands.
+theorem add_congruence_step[T: Add](r: (T, T) -> Bool, x1: T, y1: T, x2: T, y2: T) {
+    is_add_congruence(r) and r(x1, y1) and r(x2, y2) implies r(x1 + x2, y1 + y2)
+} by {
+    if is_add_congruence(r) and r(x1, y1) and r(x2, y2) {
+        is_add_congruence(r) = is_binary_congruence(r, T.add)
+        binary_congruence_step(r, T.add, x1, y1, x2, y2)
+        r(T.add(x1, x2), T.add(y1, y2))
+        r(x1 + x2, y1 + y2)
+    }
+}
+
+/// An additive congruence relation is an equivalence relation.
+theorem add_congruence_is_equivalence[T: Add](r: (T, T) -> Bool) {
+    is_add_congruence(r) implies is_equivalence(r)
+} by {
+    if is_add_congruence(r) {
+        is_add_congruence(r) = is_binary_congruence(r, T.add)
+        binary_congruence_is_equivalence(r, T.add)
+        is_equivalence(r)
+    }
+}
+
+/// An additive congruence relation is compatible with addition.
+theorem add_congruence_respects_add[T: Add](r: (T, T) -> Bool) {
+    is_add_congruence(r) implies respects_add(r)
+} by {
+    if is_add_congruence(r) {
+        is_add_congruence(r) = is_binary_congruence(r, T.add)
+        binary_congruence_respects_binary_op(r, T.add)
+        respects_binary_op(r, T.add)
+        respects_add(r)
+    }
+}
+
+/// Equality is compatible with addition.
+theorem eq_relation_respects_add[T: Add] {
+    respects_add(eq_relation[T])
+} by {
+    eq_relation_respects_binary_op(T.add)
+    respects_binary_op(eq_relation[T], T.add)
+    respects_add(eq_relation[T])
+}
+
+/// Equality is an additive congruence relation.
+theorem eq_relation_is_add_congruence[T: Add] {
+    is_add_congruence(eq_relation[T])
+} by {
+    eq_relation_is_binary_congruence(T.add)
+    is_binary_congruence(eq_relation[T], T.add)
+    is_add_congruence(eq_relation[T])
+}
+
+/// An addition-preserving map may be rewritten at any pair of inputs.
+theorem preserves_add_step[A: Add, B: Add](f: A -> B, x: A, y: A) {
+    preserves_add(f) implies f(x + y) = f(x) + f(y)
+} by {
+    if preserves_add(f) {
+        preserves_add(f) = preserves_binary_op(f, A.add, B.add)
+        preserves_binary_op_step(f, A.add, B.add, x, y)
+        f(A.add(x, y)) = B.add(f(x), f(y))
+        f(x + y) = f(x) + f(y)
+    }
+}
+
+/// Pullback preserves additive compatibility along addition-preserving maps.
+theorem relation_pullback_respects_add_of_preserves_add[A: Add, B: Add](f: A -> B, r: (B, B) -> Bool) {
+    respects_add(r) and preserves_add(f) implies respects_add(relation_pullback(f, r))
+} by {
+    if respects_add(r) and preserves_add(f) {
+        respects_add(r) = respects_binary_op(r, B.add)
+        preserves_add(f) = preserves_binary_op(f, A.add, B.add)
+        relation_pullback_respects_binary_op_of_preserves_binary_op(f, r, A.add, B.add)
+        respects_binary_op(relation_pullback(f, r), A.add)
+        respects_add(relation_pullback(f, r))
+    }
+}
+
+/// Pullback preserves additive congruence along addition-preserving maps.
+theorem relation_pullback_is_add_congruence_of_preserves_add[A: Add, B: Add](f: A -> B, r: (B, B) -> Bool) {
+    is_add_congruence(r) and preserves_add(f) implies is_add_congruence(relation_pullback(f, r))
+} by {
+    if is_add_congruence(r) and preserves_add(f) {
+        is_add_congruence(r) = is_binary_congruence(r, B.add)
+        preserves_add(f) = preserves_binary_op(f, A.add, B.add)
+        relation_pullback_is_binary_congruence_of_preserves_binary_op(f, r, A.add, B.add)
+        is_binary_congruence(relation_pullback(f, r), A.add)
+        is_add_congruence(relation_pullback(f, r))
+    }
+}
+
+/// Surjective pullback exactly detects additive compatibility along addition-preserving maps.
+theorem relation_pullback_respects_add_iff_of_surjective[A: Add, B: Add](f: A -> B, r: (B, B) -> Bool) {
+    is_surjective_fn(f) and preserves_add(f) implies
+    respects_add(relation_pullback(f, r)) = respects_add(r)
+} by {
+    if is_surjective_fn(f) and preserves_add(f) {
+        preserves_add(f) = preserves_binary_op(f, A.add, B.add)
+        relation_pullback_respects_binary_op_iff_of_surjective(f, r, A.add, B.add)
+        respects_binary_op(relation_pullback(f, r), A.add) = respects_binary_op(r, B.add)
+        respects_add(relation_pullback(f, r)) = respects_add(r)
+    }
+}
+
+/// Surjective pullback exactly detects additive congruence along addition-preserving maps.
+theorem relation_pullback_is_add_congruence_iff_of_surjective[A: Add, B: Add](f: A -> B, r: (B, B) -> Bool) {
+    is_surjective_fn(f) and preserves_add(f) implies
+    is_add_congruence(relation_pullback(f, r)) = is_add_congruence(r)
+} by {
+    if is_surjective_fn(f) and preserves_add(f) {
+        preserves_add(f) = preserves_binary_op(f, A.add, B.add)
+        relation_pullback_is_binary_congruence_iff_of_surjective(f, r, A.add, B.add)
+        is_binary_congruence(relation_pullback(f, r), A.add) = is_binary_congruence(r, B.add)
+        is_add_congruence(relation_pullback(f, r)) = is_add_congruence(r)
+    }
+}
+
+/// Bijective pushforward preserves additive compatibility along addition-preserving maps.
+theorem relation_pushforward_respects_add_of_bijection[A: Add, B: Add](f: A -> B, r: (A, A) -> Bool) {
+    is_bijection_fn(f) and preserves_add(f) and respects_add(r) implies
+    respects_add(relation_pushforward(f, r))
+} by {
+    if is_bijection_fn(f) and preserves_add(f) and respects_add(r) {
+        forall(u1: B, v1: B, u2: B, v2: B) {
+            if relation_pushforward(f, r, u1, v1) and relation_pushforward(f, r, u2, v2) {
+                relation_pushforward_has_preimages(f, r, u1, v1)
+                let x1: A satisfy {
+                    exists(y1: A) {
+                        f(x1) = u1 and f(y1) = v1 and r(x1, y1)
+                    }
+                }
+                let y1: A satisfy {
+                    f(x1) = u1 and f(y1) = v1 and r(x1, y1)
+                }
+                relation_pushforward_has_preimages(f, r, u2, v2)
+                let x2: A satisfy {
+                    exists(y2: A) {
+                        f(x2) = u2 and f(y2) = v2 and r(x2, y2)
+                    }
+                }
+                let y2: A satisfy {
+                    f(x2) = u2 and f(y2) = v2 and r(x2, y2)
+                }
+                respects_add_step(r, x1, y1, x2, y2)
+                r(x1 + x2, y1 + y2)
+                preserves_add_step(f, x1, x2)
+                f(x1 + x2) = f(x1) + f(x2)
+                preserves_add_step(f, y1, y2)
+                f(y1 + y2) = f(y1) + f(y2)
+                f(x1 + x2) = u1 + u2
+                f(y1 + y2) = v1 + v2
+                relation_pushforward_intro(f, r, x1 + x2, y1 + y2)
+                relation_pushforward(f, r, u1 + u2, v1 + v2)
+            }
+        }
+        respects_add(relation_pushforward(f, r)) =
+            respects_binary_op(relation_pushforward(f, r), B.add)
+        respects_binary_op(relation_pushforward(f, r), B.add) = forall(u1: B, v1: B, u2: B, v2: B) {
+            relation_pushforward(f, r, u1, v1) and relation_pushforward(f, r, u2, v2) implies
+            relation_pushforward(f, r, B.add(u1, u2), B.add(v1, v2))
+        }
+        respects_add(relation_pushforward(f, r))
+    }
+}
+
+/// Bijective pushforward preserves additive congruence along addition-preserving maps.
+theorem relation_pushforward_is_add_congruence_of_bijection[A: Add, B: Add](f: A -> B, r: (A, A) -> Bool) {
+    is_bijection_fn(f) and preserves_add(f) and is_add_congruence(r) implies
+    is_add_congruence(relation_pushforward(f, r))
+} by {
+    if is_bijection_fn(f) and preserves_add(f) and is_add_congruence(r) {
+        is_add_congruence(r) = is_binary_congruence(r, A.add)
+        binary_congruence_is_equivalence(r, A.add)
+        is_equivalence(r)
+        relation_pushforward_is_equivalence_of_bijection(f, r)
+        is_equivalence(relation_pushforward(f, r))
+        add_congruence_respects_add(r)
+        respects_add(r)
+        relation_pushforward_respects_add_of_bijection(f, r)
+        respects_add(relation_pushforward(f, r))
+        respects_add(relation_pushforward(f, r)) = respects_binary_op(relation_pushforward(f, r), B.add)
+        is_add_congruence(relation_pushforward(f, r))
+    }
+}
+
+/// True if a relation is compatible with the multiplication operation.
+define respects_mul[T: Mul](r: (T, T) -> Bool) -> Bool {
+    respects_binary_op(r, T.mul)
+}
+
+/// True if a relation is an equivalence relation compatible with multiplication.
+define is_mul_congruence[T: Mul](r: (T, T) -> Bool) -> Bool {
+    is_binary_congruence(r, T.mul)
+}
+
+/// True if a function preserves multiplication.
+define preserves_mul[A: Mul, B: Mul](f: A -> B) -> Bool {
+    preserves_binary_op(f, A.mul, B.mul)
+}
+
+/// Multiplicative compatibility is binary-operation compatibility for multiplication.
+theorem respects_mul_eq_respects_binary_op[T: Mul](r: (T, T) -> Bool) {
+    respects_mul(r) = respects_binary_op(r, T.mul)
+}
+
+/// Multiplicative congruence is binary congruence for multiplication.
+theorem mul_congruence_eq_binary_congruence[T: Mul](r: (T, T) -> Bool) {
+    is_mul_congruence(r) = is_binary_congruence(r, T.mul)
+}
+
+/// Multiplicative preservation is binary-operation preservation for multiplication.
+theorem preserves_mul_eq_preserves_binary_op[A: Mul, B: Mul](f: A -> B) {
+    preserves_mul(f) = preserves_binary_op(f, A.mul, B.mul)
+}
+
+/// A multiplicative-compatible relation may be applied to related factors.
+theorem respects_mul_step[T: Mul](r: (T, T) -> Bool, x1: T, y1: T, x2: T, y2: T) {
+    respects_mul(r) and r(x1, y1) and r(x2, y2) implies r(x1 * x2, y1 * y2)
+} by {
+    if respects_mul(r) and r(x1, y1) and r(x2, y2) {
+        respects_mul(r) = respects_binary_op(r, T.mul)
+        respects_binary_op_step(r, T.mul, x1, y1, x2, y2)
+        r(T.mul(x1, x2), T.mul(y1, y2))
+        r(x1 * x2, y1 * y2)
+    }
+}
+
+/// A multiplicative congruence may be applied to related factors.
+theorem mul_congruence_step[T: Mul](r: (T, T) -> Bool, x1: T, y1: T, x2: T, y2: T) {
+    is_mul_congruence(r) and r(x1, y1) and r(x2, y2) implies r(x1 * x2, y1 * y2)
+} by {
+    if is_mul_congruence(r) and r(x1, y1) and r(x2, y2) {
+        is_mul_congruence(r) = is_binary_congruence(r, T.mul)
+        binary_congruence_step(r, T.mul, x1, y1, x2, y2)
+        r(T.mul(x1, x2), T.mul(y1, y2))
+        r(x1 * x2, y1 * y2)
+    }
+}
+
+/// A multiplicative congruence relation is an equivalence relation.
+theorem mul_congruence_is_equivalence[T: Mul](r: (T, T) -> Bool) {
+    is_mul_congruence(r) implies is_equivalence(r)
+} by {
+    if is_mul_congruence(r) {
+        is_mul_congruence(r) = is_binary_congruence(r, T.mul)
+        binary_congruence_is_equivalence(r, T.mul)
+        is_equivalence(r)
+    }
+}
+
+/// A multiplicative congruence relation is compatible with multiplication.
+theorem mul_congruence_respects_mul[T: Mul](r: (T, T) -> Bool) {
+    is_mul_congruence(r) implies respects_mul(r)
+} by {
+    if is_mul_congruence(r) {
+        is_mul_congruence(r) = is_binary_congruence(r, T.mul)
+        binary_congruence_respects_binary_op(r, T.mul)
+        respects_binary_op(r, T.mul)
+        respects_mul(r)
+    }
+}
+
+/// Equality is compatible with multiplication.
+theorem eq_relation_respects_mul[T: Mul] {
+    respects_mul(eq_relation[T])
+} by {
+    eq_relation_respects_binary_op(T.mul)
+    respects_binary_op(eq_relation[T], T.mul)
+    respects_mul(eq_relation[T])
+}
+
+/// Equality is a multiplicative congruence relation.
+theorem eq_relation_is_mul_congruence[T: Mul] {
+    is_mul_congruence(eq_relation[T])
+} by {
+    eq_relation_is_binary_congruence(T.mul)
+    is_binary_congruence(eq_relation[T], T.mul)
+    is_mul_congruence(eq_relation[T])
+}
+
+/// A multiplication-preserving map may be rewritten at any pair of inputs.
+theorem preserves_mul_step[A: Mul, B: Mul](f: A -> B, x: A, y: A) {
+    preserves_mul(f) implies f(x * y) = f(x) * f(y)
+} by {
+    if preserves_mul(f) {
+        preserves_mul(f) = preserves_binary_op(f, A.mul, B.mul)
+        preserves_binary_op_step(f, A.mul, B.mul, x, y)
+        f(A.mul(x, y)) = B.mul(f(x), f(y))
+        f(x * y) = f(x) * f(y)
+    }
+}
+
+/// Pullback preserves multiplicative compatibility along multiplication-preserving maps.
+theorem relation_pullback_respects_mul_of_preserves_mul[A: Mul, B: Mul](f: A -> B, r: (B, B) -> Bool) {
+    respects_mul(r) and preserves_mul(f) implies respects_mul(relation_pullback(f, r))
+} by {
+    if respects_mul(r) and preserves_mul(f) {
+        respects_mul(r) = respects_binary_op(r, B.mul)
+        preserves_mul(f) = preserves_binary_op(f, A.mul, B.mul)
+        relation_pullback_respects_binary_op_of_preserves_binary_op(f, r, A.mul, B.mul)
+        respects_binary_op(relation_pullback(f, r), A.mul)
+        respects_mul(relation_pullback(f, r))
+    }
+}
+
+/// Pullback preserves multiplicative congruence along multiplication-preserving maps.
+theorem relation_pullback_is_mul_congruence_of_preserves_mul[A: Mul, B: Mul](f: A -> B, r: (B, B) -> Bool) {
+    is_mul_congruence(r) and preserves_mul(f) implies is_mul_congruence(relation_pullback(f, r))
+} by {
+    if is_mul_congruence(r) and preserves_mul(f) {
+        is_mul_congruence(r) = is_binary_congruence(r, B.mul)
+        preserves_mul(f) = preserves_binary_op(f, A.mul, B.mul)
+        relation_pullback_is_binary_congruence_of_preserves_binary_op(f, r, A.mul, B.mul)
+        is_binary_congruence(relation_pullback(f, r), A.mul)
+        is_mul_congruence(relation_pullback(f, r))
+    }
+}
+
+/// Surjective pullback exactly detects multiplicative compatibility along multiplication-preserving maps.
+theorem relation_pullback_respects_mul_iff_of_surjective[A: Mul, B: Mul](f: A -> B, r: (B, B) -> Bool) {
+    is_surjective_fn(f) and preserves_mul(f) implies
+    respects_mul(relation_pullback(f, r)) = respects_mul(r)
+} by {
+    if is_surjective_fn(f) and preserves_mul(f) {
+        preserves_mul(f) = preserves_binary_op(f, A.mul, B.mul)
+        relation_pullback_respects_binary_op_iff_of_surjective(f, r, A.mul, B.mul)
+        respects_binary_op(relation_pullback(f, r), A.mul) = respects_binary_op(r, B.mul)
+        respects_mul(relation_pullback(f, r)) = respects_mul(r)
+    }
+}
+
+/// Surjective pullback exactly detects multiplicative congruence along multiplication-preserving maps.
+theorem relation_pullback_is_mul_congruence_iff_of_surjective[A: Mul, B: Mul](f: A -> B, r: (B, B) -> Bool) {
+    is_surjective_fn(f) and preserves_mul(f) implies
+    is_mul_congruence(relation_pullback(f, r)) = is_mul_congruence(r)
+} by {
+    if is_surjective_fn(f) and preserves_mul(f) {
+        preserves_mul(f) = preserves_binary_op(f, A.mul, B.mul)
+        relation_pullback_is_binary_congruence_iff_of_surjective(f, r, A.mul, B.mul)
+        is_binary_congruence(relation_pullback(f, r), A.mul) = is_binary_congruence(r, B.mul)
+        is_mul_congruence(relation_pullback(f, r)) = is_mul_congruence(r)
+    }
+}
+
+/// Bijective pushforward preserves multiplicative compatibility along multiplication-preserving maps.
+theorem relation_pushforward_respects_mul_of_bijection[A: Mul, B: Mul](f: A -> B, r: (A, A) -> Bool) {
+    is_bijection_fn(f) and preserves_mul(f) and respects_mul(r) implies
+    respects_mul(relation_pushforward(f, r))
+} by {
+    if is_bijection_fn(f) and preserves_mul(f) and respects_mul(r) {
+        forall(u1: B, v1: B, u2: B, v2: B) {
+            if relation_pushforward(f, r, u1, v1) and relation_pushforward(f, r, u2, v2) {
+                relation_pushforward_has_preimages(f, r, u1, v1)
+                let x1: A satisfy {
+                    exists(y1: A) {
+                        f(x1) = u1 and f(y1) = v1 and r(x1, y1)
+                    }
+                }
+                let y1: A satisfy {
+                    f(x1) = u1 and f(y1) = v1 and r(x1, y1)
+                }
+                relation_pushforward_has_preimages(f, r, u2, v2)
+                let x2: A satisfy {
+                    exists(y2: A) {
+                        f(x2) = u2 and f(y2) = v2 and r(x2, y2)
+                    }
+                }
+                let y2: A satisfy {
+                    f(x2) = u2 and f(y2) = v2 and r(x2, y2)
+                }
+                respects_mul_step(r, x1, y1, x2, y2)
+                r(x1 * x2, y1 * y2)
+                preserves_mul_step(f, x1, x2)
+                f(x1 * x2) = f(x1) * f(x2)
+                preserves_mul_step(f, y1, y2)
+                f(y1 * y2) = f(y1) * f(y2)
+                f(x1 * x2) = u1 * u2
+                f(y1 * y2) = v1 * v2
+                relation_pushforward_intro(f, r, x1 * x2, y1 * y2)
+                relation_pushforward(f, r, u1 * u2, v1 * v2)
+            }
+        }
+        respects_mul(relation_pushforward(f, r)) =
+            respects_binary_op(relation_pushforward(f, r), B.mul)
+        respects_binary_op(relation_pushforward(f, r), B.mul) = forall(u1: B, v1: B, u2: B, v2: B) {
+            relation_pushforward(f, r, u1, v1) and relation_pushforward(f, r, u2, v2) implies
+            relation_pushforward(f, r, B.mul(u1, u2), B.mul(v1, v2))
+        }
+        respects_mul(relation_pushforward(f, r))
+    }
+}
+
+/// Bijective pushforward preserves multiplicative congruence along multiplication-preserving maps.
+theorem relation_pushforward_is_mul_congruence_of_bijection[A: Mul, B: Mul](f: A -> B, r: (A, A) -> Bool) {
+    is_bijection_fn(f) and preserves_mul(f) and is_mul_congruence(r) implies
+    is_mul_congruence(relation_pushforward(f, r))
+} by {
+    if is_bijection_fn(f) and preserves_mul(f) and is_mul_congruence(r) {
+        is_mul_congruence(r) = is_binary_congruence(r, A.mul)
+        binary_congruence_is_equivalence(r, A.mul)
+        is_equivalence(r)
+        relation_pushforward_is_equivalence_of_bijection(f, r)
+        is_equivalence(relation_pushforward(f, r))
+        mul_congruence_respects_mul(r)
+        respects_mul(r)
+        relation_pushforward_respects_mul_of_bijection(f, r)
+        respects_mul(relation_pushforward(f, r))
+        respects_mul(relation_pushforward(f, r)) = respects_binary_op(relation_pushforward(f, r), B.mul)
+        is_mul_congruence(relation_pushforward(f, r))
+    }
+}
+
+/// True if a function preserves the less-than-or-equal relation.
+define preserves_lte[A: LTE, B: LTE](f: A -> B) -> Bool {
+    respects_equivalence(f, A.lte, B.lte)
+}
+
+/// Order preservation is relation preservation for the less-than-or-equal relation.
+theorem preserves_lte_eq_respects_equivalence[A: LTE, B: LTE](f: A -> B) {
+    preserves_lte(f) = respects_equivalence(f, A.lte, B.lte)
+}
+
+/// An order-preserving map may be applied to a less-than-or-equal comparison.
+theorem preserves_lte_step[A: LTE, B: LTE](f: A -> B, x: A, y: A) {
+    preserves_lte(f) and x <= y implies f(x) <= f(y)
+} by {
+    if preserves_lte(f) and x <= y {
+        preserves_lte(f) = respects_equivalence(f, A.lte, B.lte)
+        respects_equivalence(f, A.lte, B.lte) = forall(a: A, b: A) {
+            A.lte(a, b) implies B.lte(f(a), f(b))
+        }
+        f(x) <= f(y)
+    }
+}
+
+/// Every function respects the pulled-back less-than-or-equal relation.
+theorem function_respects_lte_pullback[A, B: LTE](f: A -> B) {
+    respects_equivalence(f, relation_pullback(f, B.lte), B.lte)
+} by {
+    function_respects_pullback(f, B.lte)
+    respects_equivalence(f, relation_pullback(f, B.lte), B.lte)
+}
+
+/// Pullback of less-than-or-equal preserves reflexive, transitive, and antisymmetric order data along injective functions.
+theorem relation_pullback_lte_is_reflexive_transitive_antisymmetric_of_injective[A, B: LTE](f: A -> B) {
+    is_injective_fn(f) and is_reflexive(B.lte) and is_transitive(B.lte) and is_antisymmetric(B.lte) implies
+    is_reflexive(relation_pullback(f, B.lte)) and
+    is_transitive(relation_pullback(f, B.lte)) and
+    is_antisymmetric(relation_pullback(f, B.lte))
+} by {
+    if is_injective_fn(f) and is_reflexive(B.lte) and is_transitive(B.lte) and is_antisymmetric(B.lte) {
+        relation_pullback_is_reflexive_transitive_antisymmetric_of_injective(f, B.lte)
+        is_reflexive(relation_pullback(f, B.lte)) and
+        is_transitive(relation_pullback(f, B.lte)) and
+        is_antisymmetric(relation_pullback(f, B.lte))
+    }
+}
+
+/// Pullback of less-than-or-equal preserves and reflects reflexive, transitive, and antisymmetric order data along bijections.
+theorem relation_pullback_lte_is_reflexive_transitive_antisymmetric_iff_of_bijection[A, B: LTE](f: A -> B) {
+    is_bijection_fn(f) implies
+    (is_reflexive(relation_pullback(f, B.lte)) and
+     is_transitive(relation_pullback(f, B.lte)) and
+     is_antisymmetric(relation_pullback(f, B.lte))) =
+    (is_reflexive(B.lte) and is_transitive(B.lte) and is_antisymmetric(B.lte))
+} by {
+    if is_bijection_fn(f) {
+        relation_pullback_is_reflexive_transitive_antisymmetric_iff_of_bijection(f, B.lte)
+        (is_reflexive(relation_pullback(f, B.lte)) and
+         is_transitive(relation_pullback(f, B.lte)) and
+         is_antisymmetric(relation_pullback(f, B.lte))) =
+        (is_reflexive(B.lte) and is_transitive(B.lte) and is_antisymmetric(B.lte))
+    }
+}
+
+/// Pushforward of less-than-or-equal preserves reflexive, transitive, and antisymmetric order data along bijections.
+theorem relation_pushforward_lte_is_reflexive_transitive_antisymmetric_of_bijection[A: LTE, B](f: A -> B) {
+    is_bijection_fn(f) and is_reflexive(A.lte) and is_transitive(A.lte) and is_antisymmetric(A.lte) implies
+    is_reflexive(relation_pushforward(f, A.lte)) and
+    is_transitive(relation_pushforward(f, A.lte)) and
+    is_antisymmetric(relation_pushforward(f, A.lte))
+} by {
+    if is_bijection_fn(f) and is_reflexive(A.lte) and is_transitive(A.lte) and is_antisymmetric(A.lte) {
+        relation_pushforward_is_reflexive_transitive_antisymmetric_of_bijection(f, A.lte)
+        is_reflexive(relation_pushforward(f, A.lte)) and
+        is_transitive(relation_pushforward(f, A.lte)) and
+        is_antisymmetric(relation_pushforward(f, A.lte))
     }
 }


### PR DESCRIPTION
## Summary
- Add additive and multiplicative relation-transport wrappers for bundled `Add` and `Mul` operations.
- Add preservation, pullback, surjective detection, and bijective pushforward congruence lemmas for addition and multiplication.
- Add initial bundled `LTE` transport wrappers for order-preserving maps and pulled-back/pushed-forward order data.
- Update the translate-mathlib roadmap for the completed bundled operation wrapper work and narrowed ordered-wrapper follow-up.

## Verification
- `acorn check`
