### PR TITLE
feat: add list interval bound lemmas

### DIFF
--- a/build/add_ordered_group.jsonl
+++ b/build/add_ordered_group.jsonl
@@ -101,56 +101,56 @@
 {"goal":"a + c >= b + d","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { lib(relation_basic).relation_converse[T0, T0](T0.gte, x0, x1) = x0 <= x1 }[G](b + d, a + c)","function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { lib(relation_basic).relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[G, G](G.gte, b + d, a + c)"]}
 {"goal":"add_ge_add","proof":[]}
 {"goal":"neg_map_apply","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](x)"]}
-{"goal":"-y <= -x","proof":["not x <= y"]}
-{"goal":"neg_map(y) <= neg_map(x)","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](y)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](x)","-y <= -x","-y <= neg_map(x)","not -y <= neg_map(x)"]}
-{"goal":"neg_map_is_antitone","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { not x1 <= x2 or x0(x2) <= x0(x1) } = is_antitone[T0, T1](x0) }[G, G](neg_map[G])","let w0: G satisfy { exists(k0: G) { w0 <= k0 and not neg_map(k0) <= neg_map(w0) } }","let w1: G satisfy { w0 <= w1 and not neg_map(w1) <= neg_map(w0) }","function(x0: G, x1: G) { not x0 <= x1 or neg_map(x1) <= neg_map(x0) }(w0, w1)","w0 <= w1","not neg_map(w1) <= neg_map(w0)","neg_map(w1) <= neg_map(w0)"]}
+{"goal":"-y <= -x","proof":[]}
+{"goal":"neg_map(y) <= neg_map(x)","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](y)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](x)"]}
+{"goal":"neg_map_is_antitone","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { not x1 <= x2 or x0(x2) <= x0(x1) } = is_antitone[T0, T1](x0) }[G, G](neg_map[G])","let w0: G satisfy { exists(k0: G) { w0 <= k0 and not neg_map(k0) <= neg_map(w0) } }","let w1: G satisfy { w0 <= w1 and not neg_map(w1) <= neg_map(w0) }","function(x0: G, x1: G) { not x0 <= x1 or neg_map(x1) <= neg_map(x0) }(w0, w1)"]}
 {"goal":"neg_map(y) = -y","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](y)"]}
 {"goal":"neg_map(x) = -x","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](x)"]}
-{"goal":"--x <= --y","proof":["not -y <= -x","not neg_map(y) <= -x","neg_map(y) <= -x"]}
+{"goal":"--x <= --y","proof":[]}
 {"goal":"--x = x","proof":["function[T0: AddGroup](x0: T0) { --x0 = x0 }[G](x)"]}
 {"goal":"--y = y","proof":["function[T0: AddGroup](x0: T0) { --x0 = x0 }[G](y)"]}
-{"goal":"x <= y","proof":["not --x <= y","--x <= y"]}
-{"goal":"neg_map_reflects_le","proof":["not neg_map(y) <= neg_map(x)"]}
-{"goal":"x <= y","proof":["function[T0: LinearOrder](x0: T0, x1: T0) { x0.max(x1) = x1 = x0 <= x1 }[G](x, y)","function[T0: LinearOrder](x0: T0, x1: T0) { not x0 < x1 or x0.max(x1) = x1 }[G](x, y)","x.max(y) != y","x.max(y) = y"]}
-{"goal":"-y <= -x","proof":["not x <= y"]}
-{"goal":"--y = --x","proof":["-y != -x"]}
-{"goal":"y = x","proof":["function[T0: AddGroup](x0: T0) { --x0 = x0 }[G](y)","function[T0: AddGroup](x0: T0) { --x0 = x0 }[G](x)","--y = x","--y != x"]}
-{"goal":"x != y","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { x0 > x1 = x1 < x0 }[G](y, x)","function[T0: PartialOrder](x0: T0, x1: T0) { not x0 > x1 or x0 != x1 }[G](y, x)","y > x","not y > x"]}
+{"goal":"x <= y","proof":[]}
+{"goal":"neg_map_reflects_le","proof":[]}
+{"goal":"x <= y","proof":["function[T0: LinearOrder](x0: T0, x1: T0) { x0.max(x1) = x1 = x0 <= x1 }[G](x, y)","function[T0: LinearOrder](x0: T0, x1: T0) { not x0 < x1 or x0.max(x1) = x1 }[G](x, y)"]}
+{"goal":"-y <= -x","proof":[]}
+{"goal":"--y = --x","proof":[]}
+{"goal":"y = x","proof":["function[T0: AddGroup](x0: T0) { --x0 = x0 }[G](y)","function[T0: AddGroup](x0: T0) { --x0 = x0 }[G](x)"]}
+{"goal":"x != y","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { x0 > x1 = x1 < x0 }[G](y, x)","function[T0: PartialOrder](x0: T0, x1: T0) { not x0 > x1 or x0 != x1 }[G](y, x)"]}
 {"goal":"false","proof":[]}
-{"goal":"-y != -x","proof":["false = true"]}
-{"goal":"-y < -x","proof":["function[T0: LinearOrder](x0: T0, x1: T0) { not x0 <= x1 or x0 < x1 or x0 = x1 }[G](-y, -x)","-y <= -x"]}
-{"goal":"neg_map(y) < neg_map(x)","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](y)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](x)","-y < neg_map(x)","not -y < neg_map(x)"]}
-{"goal":"neg_map_is_strict_antitone","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { not x1 < x2 or x0(x2) < x0(x1) } = is_strict_antitone[T0, T1](x0) }[G, G](neg_map[G])","let w0: G satisfy { exists(k0: G) { w0 < k0 and not neg_map(k0) < neg_map(w0) } }","let w1: G satisfy { w0 < w1 and not neg_map(w1) < neg_map(w0) }","function(x0: G, x1: G) { not x0 < x1 or neg_map(x1) < neg_map(x0) }(w0, w1)","w0 < w1","not neg_map(w1) < neg_map(w0)","neg_map(w1) < neg_map(w0)"]}
+{"goal":"-y != -x","proof":[]}
+{"goal":"-y < -x","proof":["function[T0: LinearOrder](x0: T0, x1: T0) { not x0 <= x1 or x0 < x1 or x0 = x1 }[G](-y, -x)"]}
+{"goal":"neg_map(y) < neg_map(x)","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](y)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](x)"]}
+{"goal":"neg_map_is_strict_antitone","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { not x1 < x2 or x0(x2) < x0(x1) } = is_strict_antitone[T0, T1](x0) }[G, G](neg_map[G])","let w0: G satisfy { exists(k0: G) { w0 < k0 and not neg_map(k0) < neg_map(w0) } }","let w1: G satisfy { w0 < w1 and not neg_map(w1) < neg_map(w0) }","function(x0: G, x1: G) { not x0 < x1 or neg_map(x1) < neg_map(x0) }(w0, w1)"]}
 {"goal":"neg_map(y) = -y","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](y)"]}
 {"goal":"neg_map(x) = -x","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](x)"]}
 {"goal":"is_strict_antitone[G, G](neg_map[G])","proof":[]}
-{"goal":"neg_map(-x) < neg_map(-y)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T0, x2: T0) { not is_strict_antitone[T0, T1](x0) or not x1 < x2 or x0(x2) < x0(x1) }[G, G](neg_map[G], -y, neg_map(x))","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](x)","function[T0: AddOrderedGroup] { is_strict_antitone[T0, T0](neg_map[T0]) }[G]","not neg_map(neg_map(x)) < neg_map(-y)","-y < neg_map(x)","not -y < neg_map(x)"]}
-{"goal":"--x < --y","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](-x)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](-y)","not --x < neg_map(-y)","--x < neg_map(-y)"]}
-{"goal":"x < y","proof":["function[T0: AddGroup](x0: T0) { --x0 = x0 }[G](x)","function[T0: AddGroup](x0: T0) { --x0 = x0 }[G](y)","--x < y","not --x < y"]}
-{"goal":"neg_map_reflects_lt","proof":["not neg_map(y) < neg_map(x)"]}
-{"goal":"-b <= -a","proof":["not a <= b"]}
-{"goal":"neg_le_neg","proof":["not a <= b"]}
-{"goal":"a <= b","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](a)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](b)","not neg_map(b) <= neg_map(a)","neg_map(b) <= -a","not neg_map(b) <= -a"]}
-{"goal":"le_of_neg_le_neg","proof":["not -b <= -a"]}
+{"goal":"neg_map(-x) < neg_map(-y)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T0, x2: T0) { not is_strict_antitone[T0, T1](x0) or not x1 < x2 or x0(x2) < x0(x1) }[G, G](neg_map[G], -y, neg_map(x))"]}
+{"goal":"--x < --y","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](-x)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](-y)"]}
+{"goal":"x < y","proof":["function[T0: AddGroup](x0: T0) { --x0 = x0 }[G](x)","function[T0: AddGroup](x0: T0) { --x0 = x0 }[G](y)"]}
+{"goal":"neg_map_reflects_lt","proof":[]}
+{"goal":"-b <= -a","proof":[]}
+{"goal":"neg_le_neg","proof":[]}
+{"goal":"a <= b","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](a)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](b)"]}
+{"goal":"le_of_neg_le_neg","proof":[]}
 {"goal":"is_strict_antitone[G, G](neg_map[G])","proof":[]}
 {"goal":"neg_map(b) < neg_map(a)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T0, x2: T0) { not is_strict_antitone[T0, T1](x0) or not x1 < x2 or x0(x2) < x0(x1) }[G, G](neg_map[G], a, b)"]}
-{"goal":"-b < -a","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](b)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](a)","not -b < neg_map(a)","-b < neg_map(a)"]}
-{"goal":"neg_lt_neg","proof":["not a < b"]}
-{"goal":"a < b","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](a)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](b)","not neg_map(b) < neg_map(a)","neg_map(b) < -a","not neg_map(b) < -a"]}
-{"goal":"lt_of_neg_lt_neg","proof":["not -b < -a"]}
-{"goal":"b <= a","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { lib(relation_basic).relation_converse[T0, T0](T0.gte, x0, x1) = x0 <= x1 }[G](b, a)","function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { lib(relation_basic).relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[G, G](G.gte, b, a)","not lib(relation_basic).relation_converse(G.gte, b, a)","lib(relation_basic).relation_converse(G.gte, b, a)"]}
-{"goal":"-a <= -b","proof":["not b <= a"]}
-{"goal":"-b >= -a","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { lib(relation_basic).relation_converse[T0, T0](T0.gte, x0, x1) = x0 <= x1 }[G](-a, -b)","function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { lib(relation_basic).relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[G, G](G.gte, -a, -b)","-a <= -b","lib(relation_basic).relation_converse(G.gte, -a, -b)","not lib(relation_basic).relation_converse(G.gte, -a, -b)"]}
-{"goal":"neg_ge_neg","proof":["not a >= b"]}
-{"goal":"-a <= -b","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { lib(relation_basic).relation_converse[T0, T0](T0.gte, x0, x1) = x0 <= x1 }[G](-a, -b)","function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { lib(relation_basic).relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[G, G](G.gte, -a, -b)","not lib(relation_basic).relation_converse(G.gte, -a, -b)","lib(relation_basic).relation_converse(G.gte, -a, -b)"]}
-{"goal":"b <= a","proof":["not -a <= -b"]}
-{"goal":"a >= b","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { lib(relation_basic).relation_converse[T0, T0](T0.gte, x0, x1) = x0 <= x1 }[G](b, a)","function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { lib(relation_basic).relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[G, G](G.gte, b, a)","lib(relation_basic).relation_converse(G.gte, b, a)","not lib(relation_basic).relation_converse(G.gte, b, a)"]}
-{"goal":"ge_of_neg_ge_neg","proof":["not -b >= -a"]}
-{"goal":"b < a","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x0 > x1 }[G](a, b)","function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x1 < x0 }[G](a, b)","not a <= b and b <= a","not (not a <= b and b <= a)"]}
-{"goal":"-a < -b","proof":["not b < a"]}
-{"goal":"-b > -a","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x0 > x1 }[G](-b, -a)","function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x1 < x0 }[G](-b, -a)","not (not -b <= -a and -a <= -b)","not -b <= -a and -a <= -b"]}
-{"goal":"neg_gt_neg","proof":["not a > b"]}
-{"goal":"-a < -b","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x0 > x1 }[G](-b, -a)","function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x1 < x0 }[G](-b, -a)","not -b <= -a and -a <= -b","not (not -b <= -a and -a <= -b)"]}
-{"goal":"b < a","proof":["not -a < -b"]}
-{"goal":"a > b","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x0 > x1 }[G](a, b)","function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x1 < x0 }[G](a, b)","b < a","not (not a <= b and b <= a)","not a <= b and b <= a"]}
-{"goal":"gt_of_neg_gt_neg","proof":["not -b > -a"]}
+{"goal":"-b < -a","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](b)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](a)"]}
+{"goal":"neg_lt_neg","proof":[]}
+{"goal":"a < b","proof":["function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](a)","function[T0: AddOrderedGroup](x0: T0) { -x0 = neg_map[T0](x0) }[G](b)"]}
+{"goal":"lt_of_neg_lt_neg","proof":[]}
+{"goal":"b <= a","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { lib(relation_basic).relation_converse[T0, T0](T0.gte, x0, x1) = x0 <= x1 }[G](b, a)","function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { lib(relation_basic).relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[G, G](G.gte, b, a)"]}
+{"goal":"-a <= -b","proof":[]}
+{"goal":"-b >= -a","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { lib(relation_basic).relation_converse[T0, T0](T0.gte, x0, x1) = x0 <= x1 }[G](-a, -b)","function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { lib(relation_basic).relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[G, G](G.gte, -a, -b)"]}
+{"goal":"neg_ge_neg","proof":[]}
+{"goal":"-a <= -b","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { lib(relation_basic).relation_converse[T0, T0](T0.gte, x0, x1) = x0 <= x1 }[G](-a, -b)","function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { lib(relation_basic).relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[G, G](G.gte, -a, -b)"]}
+{"goal":"b <= a","proof":[]}
+{"goal":"a >= b","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { lib(relation_basic).relation_converse[T0, T0](T0.gte, x0, x1) = x0 <= x1 }[G](b, a)","function[T0, T1](x0: (T0, T1) -> Bool, x1: T1, x2: T0) { lib(relation_basic).relation_converse[T0, T1](x0, x1, x2) = x0(x2, x1) }[G, G](G.gte, b, a)"]}
+{"goal":"ge_of_neg_ge_neg","proof":[]}
+{"goal":"b < a","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x0 > x1 }[G](a, b)","function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x1 < x0 }[G](a, b)"]}
+{"goal":"-a < -b","proof":[]}
+{"goal":"-b > -a","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x0 > x1 }[G](-b, -a)","function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x1 < x0 }[G](-b, -a)"]}
+{"goal":"neg_gt_neg","proof":[]}
+{"goal":"-a < -b","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x0 > x1 }[G](-b, -a)","function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x1 < x0 }[G](-b, -a)"]}
+{"goal":"b < a","proof":[]}
+{"goal":"a > b","proof":["function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x0 > x1 }[G](a, b)","function[T0: PartialOrder](x0: T0, x1: T0) { (not x0 <= x1 and x1 <= x0) = x1 < x0 }[G](a, b)"]}
+{"goal":"gt_of_neg_gt_neg","proof":[]}

--- a/build/list/list_order.jsonl
+++ b/build/list/list_order.jsonl
@@ -57,6 +57,45 @@
 {"goal":"p(List.nil[T])","proof":["function(x0: List[T]) { not is_lower_bound(x0, lb2) or p(x0) }(List.nil[T])"]}
 {"goal":"p(List.cons(head, tail))","proof":["function(x0: List[T]) { not is_lower_bound(x0, lb2) or p(x0) }(List.cons(head, tail))","function(x0: List[T]) { is_lower_bound(x0, lb1) or p(x0) }(List.cons(head, tail))","function(x0: List[T]) { not lb2 <= lb1 or not is_lower_bound(x0, lb1) or not p(x0) or is_lower_bound(x0, lb2) }(tail)","function(x0: List[T]) { not is_lower_bound(x0, lb1) or not p(x0) or is_lower_bound(x0, lb2) }(tail)","function[T0: LinearOrder](x0: T0, x1: T0, x2: List[T0], x3: List[T0]) { not T0.lte(x0, x1) or not is_lower_bound[T0](x2, x0) or List.cons[T0](x1, x2) != x3 or is_lower_bound[T0](x3, x0) }[T](lb2, head, tail, List.cons(head, tail))","function[T0: LinearOrder](x0: List[T0], x1: T0, x2: T0, x3: List[T0]) { not is_lower_bound[T0](x0, x1) or List.cons[T0](x2, x3) != x0 or is_lower_bound[T0](x3, x1) }[T](List.cons(head, tail), lb1, head, tail)","function[T0: LinearOrder](x0: List[T0], x1: T0, x2: T0, x3: List[T0]) { not is_lower_bound[T0](x0, x1) or List.cons[T0](x2, x3) != x0 or T0.lte(x1, x2) }[T](List.cons(head, tail), lb1, head, tail)","function[T0](x0: (T0, T0) -> Bool, x1: T0, x2: T0, x3: T0) { not lib(util).is_transitive[T0](x0) or not x0(x1, x2) or not x0(x2, x3) or x0(x1, x3) }[T](T.lte, lb2, lb1, head)","function[T0: lib(order).PartialOrder] { lib(util).is_transitive[T0](T0.lte) }[T]"]}
 {"goal":"lower_bound_monotone","proof":["function(x0: List[T]) { (not is_lower_bound(x0, lb1) or not lb2 <= lb1 or is_lower_bound(x0, lb2)) = p(x0) }(list)","function[T0](x0: List[T0] -> Bool, x1: List[T0]) { not x0(List.nil[T0]) or exists(k0: T0, k1: List[T0]) { x0(k1) and not x0(List.cons[T0](k0, k1)) } or x0(x1) }[T](p, list)","function(x0: List[T]) { not (is_lower_bound(x0, lb1) and lb2 <= lb1 and not is_lower_bound(x0, lb2)) or not p(x0) }(list)","function(x0: List[T]) { not (is_lower_bound(x0, lb1) and lb2 <= lb1) or not p(x0) or is_lower_bound(x0, lb2) }(list)","not p(list)","exists(k0: T, k1: List[T]) { p(k1) and not p(List.cons(k0, k1)) }","let w11: T satisfy { exists(k2: List[T]) { p(k2) and not p(List.cons(w11, k2)) } }","exists(k3: List[T]) { p(k3) and not p(List.cons(w11, k3)) }","let w12: List[T] satisfy { p(w12) and not p(List.cons(w11, w12)) }","function(x0: List[T], x1: T) { not p(x0) or p(List.cons(x1, x0)) }(w12, w11)"]}
+{"goal":"is_interval_bound(list, lower, upper) = (is_lower_bound(list, lower) and is_upper_bound(list, upper))","proof":["function[T0: LinearOrder](x0: List[T0], x1: T0, x2: T0) { (is_lower_bound[T0](x0, x1) and is_upper_bound[T0](x0, x2)) = is_interval_bound[T0](x0, x1, x2) }[T](list, lower, upper)"]}
+{"goal":"is_lower_bound(list, lower)","proof":[]}
+{"goal":"lower <= item","proof":[]}
+{"goal":"is_upper_bound(list, upper)","proof":[]}
+{"goal":"item <= upper","proof":[]}
+{"goal":"closed_interval(lower, upper, item)","proof":["function[T0: LinearOrder](x0: T0, x1: T0, x2: T0) { not x0 <= x1 or not x1 <= x2 or closed_interval[T0](x0, x2, x1) }[T](lower, item, upper)"]}
+{"goal":"interval_bound_contains","proof":[]}
+{"goal":"is_interval_bound(list, lower, upper)","proof":["function[T0: LinearOrder](x0: List[T0], x1: T0, x2: T0) { (is_lower_bound[T0](x0, x1) and is_upper_bound[T0](x0, x2)) = is_interval_bound[T0](x0, x1, x2) }[T](list, lower, upper)"]}
+{"goal":"bounds_imp_interval_bound","proof":[]}
+{"goal":"is_interval_bound(list, lower, upper) = (is_lower_bound(list, lower) and is_upper_bound(list, upper))","proof":["function[T0: LinearOrder](x0: List[T0], x1: T0, x2: T0) { (is_lower_bound[T0](x0, x1) and is_upper_bound[T0](x0, x2)) = is_interval_bound[T0](x0, x1, x2) }[T](list, lower, upper)"]}
+{"goal":"is_lower_bound(list, lower)","proof":[]}
+{"goal":"interval_bound_imp_lower_bound","proof":[]}
+{"goal":"is_interval_bound(list, lower, upper) = (is_lower_bound(list, lower) and is_upper_bound(list, upper))","proof":["function[T0: LinearOrder](x0: List[T0], x1: T0, x2: T0) { (is_lower_bound[T0](x0, x1) and is_upper_bound[T0](x0, x2)) = is_interval_bound[T0](x0, x1, x2) }[T](list, lower, upper)"]}
+{"goal":"is_upper_bound(list, upper)","proof":[]}
+{"goal":"interval_bound_imp_upper_bound","proof":[]}
+{"goal":"is_lower_bound(list, lower)","proof":[]}
+{"goal":"is_upper_bound(list, upper)","proof":[]}
+{"goal":"is_lower_bound(list, lower) and is_upper_bound(list, upper)","proof":[]}
+{"goal":"is_interval_bound(list, lower, upper)","proof":[]}
+{"goal":"is_interval_bound(list, lower, upper) = (is_lower_bound(list, lower) and is_upper_bound(list, upper))","proof":[]}
+{"goal":"interval_bound_iff_bounds","proof":[]}
+{"goal":"lower <= item","proof":[]}
+{"goal":"lib(order_interval).is_lower_bound(list.contains, lower)","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0) { forall(x2: T0) { not x0(x2) or x1 <= x2 } = lib(order_interval).is_lower_bound[T0](x0, x1) }[T](list.contains, lower)","let w0: T satisfy { w0 ∈ list and not lower <= w0 }","function(x0: T) { not x0 ∈ list or lower <= x0 }(w0)"]}
+{"goal":"lower_bound_imp_contains_lower_bound","proof":[]}
+{"goal":"lib(order_interval).is_lower_bound(list.contains, lower)","proof":["not is_lower_bound(list, lower)"]}
+{"goal":"lib(order_interval).is_bounded_below[T](list.contains)","proof":["not lib(order_interval).is_lower_bound(list.contains, lower)"]}
+{"goal":"lower_bound_imp_contains_bounded_below","proof":["not is_lower_bound(list, lower)"]}
+{"goal":"item <= upper","proof":[]}
+{"goal":"lib(order_interval).is_upper_bound(list.contains, upper)","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0) { forall(x2: T0) { not x0(x2) or x2 <= x1 } = lib(order_interval).is_upper_bound[T0](x0, x1) }[T](list.contains, upper)","let w0: T satisfy { w0 ∈ list and not w0 <= upper }","function(x0: T) { not x0 ∈ list or x0 <= upper }(w0)"]}
+{"goal":"upper_bound_imp_contains_upper_bound","proof":[]}
+{"goal":"lib(order_interval).is_upper_bound(list.contains, upper)","proof":["not is_upper_bound(list, upper)"]}
+{"goal":"lib(order_interval).is_bounded_above[T](list.contains)","proof":["not lib(order_interval).is_upper_bound(list.contains, upper)"]}
+{"goal":"upper_bound_imp_contains_bounded_above","proof":["not is_upper_bound(list, upper)"]}
+{"goal":"closed_interval(lower, upper, item)","proof":[]}
+{"goal":"lib(order_interval).is_bounded_by_interval(list.contains, lower, upper)","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0, x2: T0) { forall(x3: T0) { not x0(x3) or closed_interval[T0](x1, x2, x3) } = lib(order_interval).is_bounded_by_interval[T0](x0, x1, x2) }[T](list.contains, lower, upper)","let w0: T satisfy { w0 ∈ list and not closed_interval(lower, upper, w0) }","function(x0: T) { not x0 ∈ list or closed_interval(lower, upper, x0) }(w0)"]}
+{"goal":"interval_bound_imp_contains_bounded_by_interval","proof":[]}
+{"goal":"lib(order_interval).is_bounded_by_interval(list.contains, lower, upper)","proof":["not is_interval_bound(list, lower, upper)"]}
+{"goal":"lib(order_interval).is_bounded[T](list.contains)","proof":["not lib(order_interval).is_bounded_by_interval(list.contains, lower, upper)"]}
+{"goal":"interval_bound_imp_contains_bounded","proof":["not is_interval_bound(list, lower, upper)"]}
 {"goal":"list_min(h, List.nil[T]) = h","proof":["function[T0: LinearOrder](x0: List[T0], x1: T0) { List.nil[T0] != x0 or list_min[T0](x1, x0) = x1 }[T](List.nil[T], h)"]}
 {"goal":"h <= h","proof":["function[T0: LinearOrder](x0: T0, x1: T0) { T0.lte(x0, x1) or T0.lte(x1, x0) }[T](h, h)"]}
 {"goal":"is_lower_bound(List.nil[T], h)","proof":["function[T0: LinearOrder](x0: List[T0], x1: T0) { List.nil[T0] != x0 or is_lower_bound[T0](x0, x1) }[T](List.nil[T], h)"]}
@@ -72,3 +111,14 @@
 {"goal":"p(List.cons(next, rest))","proof":["function(x0: List[T]) { exists(k0: T) { not is_lower_bound(List.cons(k0, x0), list_min(k0, x0)) } or p(x0) }(List.cons(next, rest))","exists(k0: T) { not is_lower_bound(List.cons(k0, List.cons(next, rest)), list_min(k0, List.cons(next, rest))) }","let w10: T satisfy { not is_lower_bound(List.cons(w10, List.cons(next, rest)), list_min(w10, List.cons(next, rest))) }","function(x0: T) { is_lower_bound(List.cons(x0, List.cons(next, rest)), list_min(x0, List.cons(next, rest))) }(w10)"]}
 {"goal":"list_min_is_lower_bound","proof":["function(x0: List[T]) { forall(x1: T) { is_lower_bound(List.cons(x1, x0), list_min(x1, x0)) } = p(x0) }(tail)","function[T0](x0: List[T0] -> Bool, x1: List[T0]) { not x0(List.nil[T0]) or exists(k0: T0, k1: List[T0]) { x0(k1) and not x0(List.cons[T0](k0, k1)) } or x0(x1) }[T](p, tail)","function(x0: List[T]) { not exists(k0: T) { not is_lower_bound(List.cons(k0, x0), list_min(k0, x0)) } or not p(x0) }(tail)","function(x0: List[T], x1: T) { not p(x0) or is_lower_bound(List.cons(x1, x0), list_min(x1, x0)) }(tail, head)","not p(tail)","exists(k0: T, k1: List[T]) { p(k1) and not p(List.cons(k0, k1)) }","let w9: T satisfy { exists(k2: List[T]) { p(k2) and not p(List.cons(w9, k2)) } }","exists(k3: List[T]) { p(k3) and not p(List.cons(w9, k3)) }","let w10: List[T] satisfy { p(w10) and not p(List.cons(w9, w10)) }","function(x0: List[T], x1: T) { not p(x0) or p(List.cons(x1, x0)) }(w10, w9)"]}
 {"goal":"list_has_lower_bound","proof":["function(x0: T) { not is_lower_bound(List.cons(head, tail), x0) }(list_min(head, tail))","function[T0: LinearOrder](x0: T0, x1: List[T0]) { is_lower_bound[T0](List.cons[T0](x0, x1), list_min[T0](x0, x1)) }[T](head, tail)"]}
+{"goal":"list_min_max_interval_bound","proof":[]}
+{"goal":"list_min_max_contains_bounded_by_interval","proof":[]}
+{"goal":"list_min_max_contains_bounded","proof":["not lib(order_interval).is_bounded_by_interval(List.cons(head, tail).contains, list_min(head, tail), list_max(head, tail))"]}
+{"goal":"list_min_contains_lower_bound","proof":[]}
+{"goal":"list_min_contains_bounded_below","proof":["not lib(order_interval).is_lower_bound(List.cons(head, tail).contains, list_min(head, tail))"]}
+{"goal":"list_max_contains_upper_bound","proof":[]}
+{"goal":"list_max_contains_bounded_above","proof":["not lib(order_interval).is_upper_bound(List.cons(head, tail).contains, list_max(head, tail))"]}
+{"goal":"closed_interval(list_min(head, tail), list_max(head, tail), item)","proof":[]}
+{"goal":"list_contains_closed_interval_min_max","proof":[]}
+{"goal":"exists(k0: T, k1: T) { k0 = list_min(head, tail) and k1 = list_max(head, tail) and is_interval_bound(List.cons(head, tail), k0, k1) }","proof":[]}
+{"goal":"list_has_interval_bound","proof":["function(x0: T) { not exists(k0: T) { is_interval_bound(List.cons(head, tail), x0, k0) } }(list_min(head, tail))","function(x0: T, x1: T) { not is_interval_bound(List.cons(head, tail), x0, x1) }(list_min(head, tail), list_max(head, tail))"]}

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -33,7 +33,7 @@
     "list.list_base": "d9f98d3c5bc913d83163586c045bbc53dc2cc92b43c6f5240ccb2df3e1678eab",
     "list.list_functional": "d862be9e761860157daecbb177f6afcb77dfc8f419ba263af83ac094319207d7",
     "list.list_lattice": "4976c399f4eb07c48c919e92fc9f86ec424ad4685ba66264b4a2f5c4690c0285",
-    "list.list_order": "9a0841ed03471694a9c4980cfcf0a7245a7143d9f941f07e9d9e796e4cdffcae",
+    "list.list_order": "70ef327b251cad1cdadf034d158d7bef1044fd918079d2c42ef939a8053d460c",
     "list.list_sum": "aa5cbfafa4842db36c5c92ac40d1baaaffa1540cb0c629724e3bf223f055a00a",
     "logic": "d7669981343df935aa5d7b4a9373195ba4a10b6655ba6f78ade18102e8b9cb8b",
     "lte": "d50ad9f658e8ac3ae9d504ec97537ad6a975e8af879ed71747de765ba9619855",

--- a/build/ordered_group.jsonl
+++ b/build/ordered_group.jsonl
@@ -47,80 +47,80 @@
 {"goal":"mul_left_map_apply","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, x)"]}
 {"goal":"mul_right_map_apply","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, x)"]}
 {"goal":"c * x <= c * y","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0, x2: T0) { not x0 <= x1 or x2 * x0 <= x2 * x1 }[G](x, y, c)"]}
-{"goal":"mul_left_map(c, x) <= mul_left_map(c, y)","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, y)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, x)","not c * x <= mul_left_map(c, y)","c * x <= mul_left_map(c, y)"]}
-{"goal":"mul_left_map_is_monotone","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { not x1 <= x2 or x0(x1) <= x0(x2) } = is_monotone[T0, T1](x0) }[G, G](mul_left_map(c))","let w0: G satisfy { exists(k0: G) { w0 <= k0 and not mul_left_map(c, w0) <= mul_left_map(c, k0) } }","let w1: G satisfy { w0 <= w1 and not mul_left_map(c, w0) <= mul_left_map(c, w1) }","function(x0: G, x1: G) { not x0 <= x1 or mul_left_map(c, x0) <= mul_left_map(c, x1) }(w0, w1)","w0 <= w1","not mul_left_map(c, w0) <= mul_left_map(c, w1)","mul_left_map(c, w0) <= mul_left_map(c, w1)"]}
+{"goal":"mul_left_map(c, x) <= mul_left_map(c, y)","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, y)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, x)"]}
+{"goal":"mul_left_map_is_monotone","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { not x1 <= x2 or x0(x1) <= x0(x2) } = is_monotone[T0, T1](x0) }[G, G](mul_left_map(c))","let w0: G satisfy { exists(k0: G) { w0 <= k0 and not mul_left_map(c, w0) <= mul_left_map(c, k0) } }","let w1: G satisfy { w0 <= w1 and not mul_left_map(c, w0) <= mul_left_map(c, w1) }","function(x0: G, x1: G) { not x0 <= x1 or mul_left_map(c, x0) <= mul_left_map(c, x1) }(w0, w1)"]}
 {"goal":"x * c <= y * c","proof":["function[T0: OrderedGroup](x0: T0, x1: T0, x2: T0) { not x0 <= x1 or x0 * x2 <= x1 * x2 }[G](x, y, c)"]}
-{"goal":"mul_right_map(c, x) <= mul_right_map(c, y)","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, y)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, x)","not x * c <= mul_right_map(c, y)","x * c <= mul_right_map(c, y)"]}
-{"goal":"mul_right_map_is_monotone","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { not x1 <= x2 or x0(x1) <= x0(x2) } = is_monotone[T0, T1](x0) }[G, G](mul_right_map(c))","let w0: G satisfy { exists(k0: G) { w0 <= k0 and not mul_right_map(c, w0) <= mul_right_map(c, k0) } }","let w1: G satisfy { w0 <= w1 and not mul_right_map(c, w0) <= mul_right_map(c, w1) }","function(x0: G, x1: G) { not x0 <= x1 or mul_right_map(c, x0) <= mul_right_map(c, x1) }(w0, w1)","w0 <= w1","not mul_right_map(c, w0) <= mul_right_map(c, w1)","mul_right_map(c, w0) <= mul_right_map(c, w1)"]}
+{"goal":"mul_right_map(c, x) <= mul_right_map(c, y)","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, y)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, x)"]}
+{"goal":"mul_right_map_is_monotone","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { not x1 <= x2 or x0(x1) <= x0(x2) } = is_monotone[T0, T1](x0) }[G, G](mul_right_map(c))","let w0: G satisfy { exists(k0: G) { w0 <= k0 and not mul_right_map(c, w0) <= mul_right_map(c, k0) } }","let w1: G satisfy { w0 <= w1 and not mul_right_map(c, w0) <= mul_right_map(c, w1) }","function(x0: G, x1: G) { not x0 <= x1 or mul_right_map(c, x0) <= mul_right_map(c, x1) }(w0, w1)"]}
 {"goal":"mul_left_map(c, x) = c * x","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, x)"]}
 {"goal":"mul_left_map(c, y) = c * y","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, y)"]}
-{"goal":"c.inverse * (c * x) <= c.inverse * (c * y)","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0, x2: T0) { not x0 <= x1 or x2 * x0 <= x2 * x1 }[G](c * x, mul_left_map(c, y), c.inverse)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, y)","not c.inverse * (c * x) <= c.inverse * mul_left_map(c, y)","c * x <= mul_left_map(c, y)","not c * x <= mul_left_map(c, y)"]}
+{"goal":"c.inverse * (c * x) <= c.inverse * (c * y)","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0, x2: T0) { not x0 <= x1 or x2 * x0 <= x2 * x1 }[G](c * x, mul_left_map(c, y), c.inverse)"]}
 {"goal":"c.inverse * (c * x) = c.inverse * c * x","proof":["function[T0: lib(semigroup).Semigroup](x0: T0, x1: T0, x2: T0) { x0 * x1 * x2 = x0 * (x1 * x2) }[G](c.inverse, c, x)"]}
 {"goal":"c.inverse * (c * y) = c.inverse * c * y","proof":["function[T0: lib(semigroup).Semigroup](x0: T0, x1: T0, x2: T0) { x0 * x1 * x2 = x0 * (x1 * x2) }[G](c.inverse, c, y)"]}
 {"goal":"c.inverse * c = G.1","proof":["function[T0: Group](x0: T0) { x0.inverse * x0 = T0.1 }[G](c)"]}
 {"goal":"G.1 * x = x","proof":["function[T0: lib(monoid).Monoid](x0: T0) { T0.1 * x0 = x0 }[G](x)"]}
 {"goal":"G.1 * y = y","proof":["function[T0: lib(monoid).Monoid](x0: T0) { T0.1 * x0 = x0 }[G](y)"]}
 {"goal":"x <= y","proof":[]}
-{"goal":"mul_left_map_reflects_le","proof":["not mul_left_map(c, x) <= mul_left_map(c, y)"]}
+{"goal":"mul_left_map_reflects_le","proof":[]}
 {"goal":"mul_right_map(c, x) = x * c","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, x)"]}
 {"goal":"mul_right_map(c, y) = y * c","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, y)"]}
-{"goal":"x * c * c.inverse <= y * c * c.inverse","proof":["function[T0: OrderedGroup](x0: T0, x1: T0, x2: T0) { not x0 <= x1 or x0 * x2 <= x1 * x2 }[G](x * c, mul_right_map(c, y), c.inverse)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, y)","not x * c * c.inverse <= mul_right_map(c, y) * c.inverse","x * c <= mul_right_map(c, y)","not x * c <= mul_right_map(c, y)"]}
+{"goal":"x * c * c.inverse <= y * c * c.inverse","proof":["function[T0: OrderedGroup](x0: T0, x1: T0, x2: T0) { not x0 <= x1 or x0 * x2 <= x1 * x2 }[G](x * c, mul_right_map(c, y), c.inverse)"]}
 {"goal":"x * c * c.inverse = x * (c * c.inverse)","proof":["function[T0: lib(semigroup).Semigroup](x0: T0, x1: T0, x2: T0) { x0 * x1 * x2 = x0 * (x1 * x2) }[G](x, c, c.inverse)"]}
 {"goal":"y * c * c.inverse = y * (c * c.inverse)","proof":["function[T0: lib(semigroup).Semigroup](x0: T0, x1: T0, x2: T0) { x0 * x1 * x2 = x0 * (x1 * x2) }[G](y, c, c.inverse)"]}
 {"goal":"c * c.inverse = G.1","proof":["function[T0: Group](x0: T0) { x0 * x0.inverse = T0.1 }[G](c)"]}
 {"goal":"x * G.1 = x","proof":["function[T0: lib(monoid).Monoid](x0: T0) { x0 * T0.1 = x0 }[G](x)"]}
 {"goal":"y * G.1 = y","proof":["function[T0: lib(monoid).Monoid](x0: T0) { x0 * T0.1 = x0 }[G](y)"]}
 {"goal":"x <= y","proof":[]}
-{"goal":"mul_right_map_reflects_le","proof":["not mul_right_map(c, x) <= mul_right_map(c, y)"]}
-{"goal":"x <= y","proof":["not mul_left_map(c, x) <= mul_left_map(c, y)"]}
+{"goal":"mul_right_map_reflects_le","proof":[]}
+{"goal":"x <= y","proof":[]}
 {"goal":"is_monotone[G, G](mul_left_map(c))","proof":[]}
 {"goal":"mul_left_map(c, x) <= mul_left_map(c, y)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T0, x2: T0) { not is_monotone[T0, T1](x0) or not x1 <= x2 or x0(x1) <= x0(x2) }[G, G](mul_left_map(c), x, y)"]}
-{"goal":"mul_left_map(c, x) <= mul_left_map(c, y) = x <= y","proof":["mul_left_map(c, x) <= mul_left_map(c, y) or x <= y","x <= y","mul_left_map(c, x) <= mul_left_map(c, y)","not mul_left_map(c, x) <= mul_left_map(c, y)"]}
+{"goal":"mul_left_map(c, x) <= mul_left_map(c, y) = x <= y","proof":[]}
 {"goal":"mul_left_map_is_order_embedding","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { x1 <= x2 = x0(x1) <= x0(x2) } = is_order_embedding[T0, T1](x0) }[G, G](mul_left_map(c))","let w0: G satisfy { exists(k0: G) { w0 <= k0 != mul_left_map(c, w0) <= mul_left_map(c, k0) } }","let w1: G satisfy { w0 <= w1 != mul_left_map(c, w0) <= mul_left_map(c, w1) }","function(x0: G, x1: G) { mul_left_map(c, x0) <= mul_left_map(c, x1) = x0 <= x1 }(w0, w1)"]}
-{"goal":"x <= y","proof":["not mul_right_map(c, x) <= mul_right_map(c, y)"]}
+{"goal":"x <= y","proof":[]}
 {"goal":"is_monotone[G, G](mul_right_map(c))","proof":[]}
 {"goal":"mul_right_map(c, x) <= mul_right_map(c, y)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T0, x2: T0) { not is_monotone[T0, T1](x0) or not x1 <= x2 or x0(x1) <= x0(x2) }[G, G](mul_right_map(c), x, y)"]}
-{"goal":"mul_right_map(c, x) <= mul_right_map(c, y) = x <= y","proof":["mul_right_map(c, x) <= mul_right_map(c, y) or x <= y","x <= y","mul_right_map(c, x) <= mul_right_map(c, y)","not mul_right_map(c, x) <= mul_right_map(c, y)"]}
+{"goal":"mul_right_map(c, x) <= mul_right_map(c, y) = x <= y","proof":[]}
 {"goal":"mul_right_map_is_order_embedding","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { x1 <= x2 = x0(x1) <= x0(x2) } = is_order_embedding[T0, T1](x0) }[G, G](mul_right_map(c))","let w0: G satisfy { exists(k0: G) { w0 <= k0 != mul_right_map(c, w0) <= mul_right_map(c, k0) } }","let w1: G satisfy { w0 <= w1 != mul_right_map(c, w0) <= mul_right_map(c, w1) }","function(x0: G, x1: G) { mul_right_map(c, x0) <= mul_right_map(c, x1) = x0 <= x1 }(w0, w1)"]}
-{"goal":"mul_left_map_is_strict_monotone","proof":["not is_order_embedding[G, G](mul_left_map(c))"]}
-{"goal":"mul_right_map_is_strict_monotone","proof":["not is_order_embedding[G, G](mul_right_map(c))"]}
-{"goal":"mul_left_map(c, a) <= mul_left_map(c, b)","proof":["not is_order_embedding[G, G](mul_left_map(c)) or not a <= b","not is_order_embedding[G, G](mul_left_map(c))"]}
+{"goal":"mul_left_map_is_strict_monotone","proof":[]}
+{"goal":"mul_right_map_is_strict_monotone","proof":[]}
+{"goal":"mul_left_map(c, a) <= mul_left_map(c, b)","proof":[]}
 {"goal":"c * a <= c * b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0, x2: T0) { not x0 <= x1 or x2 * x0 <= x2 * x1 }[G](a, b, c)"]}
-{"goal":"mul_le_mul_left","proof":["not a <= b"]}
-{"goal":"mul_right_map(c, a) <= mul_right_map(c, b)","proof":["not is_order_embedding[G, G](mul_right_map(c)) or not a <= b","not is_order_embedding[G, G](mul_right_map(c))"]}
+{"goal":"mul_le_mul_left","proof":[]}
+{"goal":"mul_right_map(c, a) <= mul_right_map(c, b)","proof":[]}
 {"goal":"a * c <= b * c","proof":["function[T0: OrderedGroup](x0: T0, x1: T0, x2: T0) { not x0 <= x1 or x0 * x2 <= x1 * x2 }[G](a, b, c)"]}
-{"goal":"mul_le_mul_right","proof":["not a <= b"]}
-{"goal":"mul_left_map(c, a) < mul_left_map(c, b)","proof":["not is_order_embedding[G, G](mul_left_map(c)) or not a < b","not is_order_embedding[G, G](mul_left_map(c))"]}
-{"goal":"c * a < c * b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)","mul_left_map(c, a) < mul_left_map(c, b)","c * a < mul_left_map(c, b)","not c * a < mul_left_map(c, b)"]}
-{"goal":"mul_lt_mul_left","proof":["not a < b"]}
-{"goal":"mul_right_map(c, a) < mul_right_map(c, b)","proof":["not is_order_embedding[G, G](mul_right_map(c)) or not a < b","not is_order_embedding[G, G](mul_right_map(c))"]}
-{"goal":"a * c < b * c","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)","mul_right_map(c, a) < mul_right_map(c, b)","a * c < mul_right_map(c, b)","not a * c < mul_right_map(c, b)"]}
-{"goal":"mul_lt_mul_right","proof":["not a < b"]}
-{"goal":"mul_left_map(c, a) >= mul_left_map(c, b)","proof":["not is_order_embedding[G, G](mul_left_map(c)) or not a >= b","not is_order_embedding[G, G](mul_left_map(c))"]}
-{"goal":"c * a >= c * b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)","mul_left_map(c, a) >= mul_left_map(c, b)","c * a >= mul_left_map(c, b)","not c * a >= mul_left_map(c, b)"]}
-{"goal":"mul_ge_mul_left","proof":["not a >= b"]}
-{"goal":"mul_right_map(c, a) >= mul_right_map(c, b)","proof":["not is_order_embedding[G, G](mul_right_map(c)) or not a >= b","not is_order_embedding[G, G](mul_right_map(c))"]}
-{"goal":"a * c >= b * c","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)","mul_right_map(c, a) >= mul_right_map(c, b)","a * c >= mul_right_map(c, b)","not a * c >= mul_right_map(c, b)"]}
-{"goal":"mul_ge_mul_right","proof":["not a >= b"]}
-{"goal":"mul_left_map(c, a) > mul_left_map(c, b)","proof":["not is_order_embedding[G, G](mul_left_map(c)) or not a > b","not is_order_embedding[G, G](mul_left_map(c))"]}
-{"goal":"c * a > c * b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)","mul_left_map(c, a) > mul_left_map(c, b)","c * a > mul_left_map(c, b)","not c * a > mul_left_map(c, b)"]}
-{"goal":"mul_gt_mul_left","proof":["not a > b"]}
-{"goal":"mul_right_map(c, a) > mul_right_map(c, b)","proof":["not is_order_embedding[G, G](mul_right_map(c)) or not a > b","not is_order_embedding[G, G](mul_right_map(c))"]}
-{"goal":"a * c > b * c","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)","mul_right_map(c, a) > mul_right_map(c, b)","a * c > mul_right_map(c, b)","not a * c > mul_right_map(c, b)"]}
-{"goal":"mul_gt_mul_right","proof":["not a > b"]}
-{"goal":"a <= b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)","not mul_left_map(c, a) <= mul_left_map(c, b)","not c * a <= mul_left_map(c, b)","c * a <= mul_left_map(c, b)"]}
-{"goal":"le_of_mul_le_mul_left","proof":["not c * a <= c * b"]}
-{"goal":"a <= b","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)","not mul_right_map(c, a) <= mul_right_map(c, b)","not a * c <= mul_right_map(c, b)","a * c <= mul_right_map(c, b)"]}
-{"goal":"le_of_mul_le_mul_right","proof":["not a * c <= b * c"]}
-{"goal":"a < b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)","not mul_left_map(c, a) < mul_left_map(c, b) or not is_order_embedding[G, G](mul_left_map(c))","not mul_left_map(c, a) < mul_left_map(c, b)","not c * a < mul_left_map(c, b)","c * a < mul_left_map(c, b)"]}
-{"goal":"lt_of_mul_lt_mul_left","proof":["not c * a < c * b"]}
-{"goal":"a < b","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)","not mul_right_map(c, a) < mul_right_map(c, b) or not is_order_embedding[G, G](mul_right_map(c))","not mul_right_map(c, a) < mul_right_map(c, b)","not a * c < mul_right_map(c, b)","a * c < mul_right_map(c, b)"]}
-{"goal":"lt_of_mul_lt_mul_right","proof":["not a * c < b * c"]}
-{"goal":"a >= b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)","not mul_left_map(c, a) >= mul_left_map(c, b) or not is_order_embedding[G, G](mul_left_map(c))","not mul_left_map(c, a) >= mul_left_map(c, b)","not c * a >= mul_left_map(c, b)","c * a >= mul_left_map(c, b)"]}
-{"goal":"ge_of_mul_ge_mul_left","proof":["not c * a >= c * b"]}
-{"goal":"a >= b","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)","not mul_right_map(c, a) >= mul_right_map(c, b) or not is_order_embedding[G, G](mul_right_map(c))","not mul_right_map(c, a) >= mul_right_map(c, b)","not a * c >= mul_right_map(c, b)","a * c >= mul_right_map(c, b)"]}
-{"goal":"ge_of_mul_ge_mul_right","proof":["not a * c >= b * c"]}
-{"goal":"a > b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)","not mul_left_map(c, a) > mul_left_map(c, b) or not is_order_embedding[G, G](mul_left_map(c))","not mul_left_map(c, a) > mul_left_map(c, b)","not c * a > mul_left_map(c, b)","c * a > mul_left_map(c, b)"]}
-{"goal":"gt_of_mul_gt_mul_left","proof":["not c * a > c * b"]}
-{"goal":"a > b","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)","not mul_right_map(c, a) > mul_right_map(c, b) or not is_order_embedding[G, G](mul_right_map(c))","not mul_right_map(c, a) > mul_right_map(c, b)","not a * c > mul_right_map(c, b)","a * c > mul_right_map(c, b)"]}
-{"goal":"gt_of_mul_gt_mul_right","proof":["not a * c > b * c"]}
+{"goal":"mul_le_mul_right","proof":[]}
+{"goal":"mul_left_map(c, a) < mul_left_map(c, b)","proof":[]}
+{"goal":"c * a < c * b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)"]}
+{"goal":"mul_lt_mul_left","proof":[]}
+{"goal":"mul_right_map(c, a) < mul_right_map(c, b)","proof":[]}
+{"goal":"a * c < b * c","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)"]}
+{"goal":"mul_lt_mul_right","proof":[]}
+{"goal":"mul_left_map(c, a) >= mul_left_map(c, b)","proof":[]}
+{"goal":"c * a >= c * b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)"]}
+{"goal":"mul_ge_mul_left","proof":[]}
+{"goal":"mul_right_map(c, a) >= mul_right_map(c, b)","proof":[]}
+{"goal":"a * c >= b * c","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)"]}
+{"goal":"mul_ge_mul_right","proof":[]}
+{"goal":"mul_left_map(c, a) > mul_left_map(c, b)","proof":[]}
+{"goal":"c * a > c * b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)"]}
+{"goal":"mul_gt_mul_left","proof":[]}
+{"goal":"mul_right_map(c, a) > mul_right_map(c, b)","proof":[]}
+{"goal":"a * c > b * c","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)"]}
+{"goal":"mul_gt_mul_right","proof":[]}
+{"goal":"a <= b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)"]}
+{"goal":"le_of_mul_le_mul_left","proof":[]}
+{"goal":"a <= b","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)"]}
+{"goal":"le_of_mul_le_mul_right","proof":[]}
+{"goal":"a < b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)"]}
+{"goal":"lt_of_mul_lt_mul_left","proof":[]}
+{"goal":"a < b","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)"]}
+{"goal":"lt_of_mul_lt_mul_right","proof":[]}
+{"goal":"a >= b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)"]}
+{"goal":"ge_of_mul_ge_mul_left","proof":[]}
+{"goal":"a >= b","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)"]}
+{"goal":"ge_of_mul_ge_mul_right","proof":[]}
+{"goal":"a > b","proof":["function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, b)","function[T0: LeftOrderedGroup](x0: T0, x1: T0) { mul_left_map[T0](x0, x1) = x0 * x1 }[G](c, a)"]}
+{"goal":"gt_of_mul_gt_mul_left","proof":[]}
+{"goal":"a > b","proof":["function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, b)","function[T0: OrderedGroup](x0: T0, x1: T0) { mul_right_map[T0](x0, x1) = x1 * x0 }[G](c, a)"]}
+{"goal":"gt_of_mul_gt_mul_right","proof":[]}

--- a/projects/translate-mathlib/order-theory/order-operations-and-intervals/todo.md
+++ b/projects/translate-mathlib/order-theory/order-operations-and-intervals/todo.md
@@ -4,7 +4,6 @@ Goal: make elementwise order manipulation routine rather than bespoke.
 
 - [ ] Audit downstream `min`/`max` users for remaining bespoke one-off lemmas
 - [ ] Decide the exact interval preimage API for plain monotone maps; order-embedding interval preimages are in place
-- [ ] Connect list minima/maxima to order-theoretic interval language
 - [ ] Refactor existing interval-like proofs to use the shared API
 
 Status:
@@ -15,3 +14,4 @@ Status:
 - `src/order_interval.ac` now has endpoint consequences, endpoint membership, interval-subset, interval-bound monotonicity, and bounded-below / bounded-above projection lemmas.
 - `src/order_interval.ac` now has endpoint iff/nonmembership facts, interval emptiness and nonemptiness facts, same-shape interval subset aliases, and boundedness facts for closed, open, and half-open intervals.
 - `src/order_interval.ac` now has the core clamp API: endpoint selectors, fixed points, idempotence, element and endpoint monotonicity, and the closed-interval fixed-point characterization.
+- `src/list/list_order.ac` now connects non-empty list minima and maxima to `closed_interval` and the predicate-boundedness API via interval-bound predicates and existence theorems.

--- a/src/list/list_order.ac
+++ b/src/list/list_order.ac
@@ -1,5 +1,6 @@
 from list.list_base import List
 from order import LinearOrder
+from order_interval import closed_interval
 
 /// Theorems about lists of ordered types.
 
@@ -299,6 +300,170 @@ theorem lower_bound_monotone[T: LinearOrder](list: List[T], lb1: T, lb2: T) {
 
 }
 
+/// True if all elements of a list lie in the closed interval from `lower` to `upper`.
+define is_interval_bound[T: LinearOrder](list: List[T], lower: T, upper: T) -> Bool {
+    is_lower_bound(list, lower) and is_upper_bound(list, upper)
+}
+
+/// An interval bound applies to every element contained in the list.
+theorem interval_bound_contains[T: LinearOrder](list: List[T], lower: T, upper: T, item: T) {
+    is_interval_bound(list, lower, upper) and list.contains(item) implies
+    closed_interval(lower, upper, item)
+} by {
+    if is_interval_bound(list, lower, upper) and list.contains(item) {
+        is_interval_bound(list, lower, upper) =
+            (is_lower_bound(list, lower) and is_upper_bound(list, upper))
+        is_lower_bound(list, lower)
+        lower_bound_contains(list, lower, item)
+        lower <= item
+        is_upper_bound(list, upper)
+        upper_bound_contains(list, upper, item)
+        item <= upper
+        closed_interval(lower, upper, item)
+    }
+}
+
+/// Lower and upper list bounds determine an interval bound.
+theorem bounds_imp_interval_bound[T: LinearOrder](list: List[T], lower: T, upper: T) {
+    is_lower_bound(list, lower) and is_upper_bound(list, upper) implies
+    is_interval_bound(list, lower, upper)
+} by {
+    if is_lower_bound(list, lower) and is_upper_bound(list, upper) {
+        is_interval_bound(list, lower, upper)
+    }
+}
+
+/// An interval bound determines a lower bound for the list.
+theorem interval_bound_imp_lower_bound[T: LinearOrder](list: List[T], lower: T, upper: T) {
+    is_interval_bound(list, lower, upper) implies is_lower_bound(list, lower)
+} by {
+    if is_interval_bound(list, lower, upper) {
+        is_interval_bound(list, lower, upper) =
+            (is_lower_bound(list, lower) and is_upper_bound(list, upper))
+        is_lower_bound(list, lower)
+    }
+}
+
+/// An interval bound determines an upper bound for the list.
+theorem interval_bound_imp_upper_bound[T: LinearOrder](list: List[T], lower: T, upper: T) {
+    is_interval_bound(list, lower, upper) implies is_upper_bound(list, upper)
+} by {
+    if is_interval_bound(list, lower, upper) {
+        is_interval_bound(list, lower, upper) =
+            (is_lower_bound(list, lower) and is_upper_bound(list, upper))
+        is_upper_bound(list, upper)
+    }
+}
+
+/// Being interval-bounded is equivalent to having the corresponding lower and upper bounds.
+theorem interval_bound_iff_bounds[T: LinearOrder](list: List[T], lower: T, upper: T) {
+    is_interval_bound(list, lower, upper) =
+    (is_lower_bound(list, lower) and is_upper_bound(list, upper))
+} by {
+    if is_interval_bound(list, lower, upper) {
+        interval_bound_imp_lower_bound(list, lower, upper)
+        is_lower_bound(list, lower)
+        interval_bound_imp_upper_bound(list, lower, upper)
+        is_upper_bound(list, upper)
+        is_lower_bound(list, lower) and is_upper_bound(list, upper)
+    }
+    if is_lower_bound(list, lower) and is_upper_bound(list, upper) {
+        bounds_imp_interval_bound(list, lower, upper)
+        is_interval_bound(list, lower, upper)
+    }
+    is_interval_bound(list, lower, upper) =
+    (is_lower_bound(list, lower) and is_upper_bound(list, upper))
+}
+
+/// A list lower bound is a lower bound for the list membership predicate.
+theorem lower_bound_imp_contains_lower_bound[T: LinearOrder](list: List[T], lower: T) {
+    is_lower_bound(list, lower) implies
+    lib(order_interval).is_lower_bound(list.contains, lower)
+} by {
+    if is_lower_bound(list, lower) {
+        forall(item: T) {
+            if list.contains(item) {
+                lower_bound_contains(list, lower, item)
+                lower <= item
+            }
+        }
+        lib(order_interval).is_lower_bound(list.contains, lower)
+    }
+}
+
+/// A list lower bound gives boundedness below for the list membership predicate.
+theorem lower_bound_imp_contains_bounded_below[T: LinearOrder](list: List[T], lower: T) {
+    is_lower_bound(list, lower) implies
+    lib(order_interval).is_bounded_below(list.contains)
+} by {
+    if is_lower_bound(list, lower) {
+        lower_bound_imp_contains_lower_bound(list, lower)
+        lib(order_interval).is_lower_bound(list.contains, lower)
+        lib(order_interval).lower_bound_imp_bounded_below(list.contains, lower)
+        lib(order_interval).is_bounded_below(list.contains)
+    }
+}
+
+/// A list upper bound is an upper bound for the list membership predicate.
+theorem upper_bound_imp_contains_upper_bound[T: LinearOrder](list: List[T], upper: T) {
+    is_upper_bound(list, upper) implies
+    lib(order_interval).is_upper_bound(list.contains, upper)
+} by {
+    if is_upper_bound(list, upper) {
+        forall(item: T) {
+            if list.contains(item) {
+                upper_bound_contains(list, upper, item)
+                item <= upper
+            }
+        }
+        lib(order_interval).is_upper_bound(list.contains, upper)
+    }
+}
+
+/// A list upper bound gives boundedness above for the list membership predicate.
+theorem upper_bound_imp_contains_bounded_above[T: LinearOrder](list: List[T], upper: T) {
+    is_upper_bound(list, upper) implies
+    lib(order_interval).is_bounded_above(list.contains)
+} by {
+    if is_upper_bound(list, upper) {
+        upper_bound_imp_contains_upper_bound(list, upper)
+        lib(order_interval).is_upper_bound(list.contains, upper)
+        lib(order_interval).upper_bound_imp_bounded_above(list.contains, upper)
+        lib(order_interval).is_bounded_above(list.contains)
+    }
+}
+
+/// An interval bound for a list is an interval bound for its membership predicate.
+theorem interval_bound_imp_contains_bounded_by_interval[T: LinearOrder](list: List[T],
+        lower: T, upper: T) {
+    is_interval_bound(list, lower, upper) implies
+    lib(order_interval).is_bounded_by_interval(list.contains, lower, upper)
+} by {
+    if is_interval_bound(list, lower, upper) {
+        forall(item: T) {
+            if list.contains(item) {
+                interval_bound_contains(list, lower, upper, item)
+                closed_interval(lower, upper, item)
+            }
+        }
+        lib(order_interval).is_bounded_by_interval(list.contains, lower, upper)
+    }
+}
+
+/// An interval bound for a list gives boundedness for its membership predicate.
+theorem interval_bound_imp_contains_bounded[T: LinearOrder](list: List[T],
+        lower: T, upper: T) {
+    is_interval_bound(list, lower, upper) implies
+    lib(order_interval).is_bounded(list.contains)
+} by {
+    if is_interval_bound(list, lower, upper) {
+        interval_bound_imp_contains_bounded_by_interval(list, lower, upper)
+        lib(order_interval).is_bounded_by_interval(list.contains, lower, upper)
+        lib(order_interval).bounded_by_interval_imp_bounded(list.contains, lower, upper)
+        lib(order_interval).is_bounded(list.contains)
+    }
+}
+
 /// The minimum element of a non-empty list.
 define list_min[T: LinearOrder](head: T, tail: List[T]) -> T {
     match tail {
@@ -359,4 +524,92 @@ theorem list_has_lower_bound[T: LinearOrder](head: T, tail: List[T]) {
     }
 } by {
     let lb = list_min(head, tail)
+}
+
+/// The minimum and maximum of a non-empty list bound every element of the list by a closed interval.
+theorem list_min_max_interval_bound[T: LinearOrder](head: T, tail: List[T]) {
+    is_interval_bound(List.cons(head, tail), list_min(head, tail), list_max(head, tail))
+} by {
+    list_min_is_lower_bound(head, tail)
+    list_max_is_upper_bound(head, tail)
+    bounds_imp_interval_bound(List.cons(head, tail), list_min(head, tail), list_max(head, tail))
+}
+
+/// The list membership predicate is interval-bounded by the minimum and maximum.
+theorem list_min_max_contains_bounded_by_interval[T: LinearOrder](head: T, tail: List[T]) {
+    lib(order_interval).is_bounded_by_interval(List.cons(head, tail).contains,
+        list_min(head, tail), list_max(head, tail))
+} by {
+    list_min_max_interval_bound(head, tail)
+    interval_bound_imp_contains_bounded_by_interval(List.cons(head, tail),
+        list_min(head, tail), list_max(head, tail))
+}
+
+/// The list membership predicate is bounded.
+theorem list_min_max_contains_bounded[T: LinearOrder](head: T, tail: List[T]) {
+    lib(order_interval).is_bounded(List.cons(head, tail).contains)
+} by {
+    list_min_max_contains_bounded_by_interval(head, tail)
+    lib(order_interval).bounded_by_interval_imp_bounded(List.cons(head, tail).contains,
+        list_min(head, tail), list_max(head, tail))
+}
+
+/// The list membership predicate is bounded below by the minimum.
+theorem list_min_contains_lower_bound[T: LinearOrder](head: T, tail: List[T]) {
+    lib(order_interval).is_lower_bound(List.cons(head, tail).contains, list_min(head, tail))
+} by {
+    list_min_is_lower_bound(head, tail)
+    lower_bound_imp_contains_lower_bound(List.cons(head, tail), list_min(head, tail))
+}
+
+/// The list membership predicate is bounded below.
+theorem list_min_contains_bounded_below[T: LinearOrder](head: T, tail: List[T]) {
+    lib(order_interval).is_bounded_below(List.cons(head, tail).contains)
+} by {
+    list_min_contains_lower_bound(head, tail)
+    lib(order_interval).lower_bound_imp_bounded_below(List.cons(head, tail).contains,
+        list_min(head, tail))
+}
+
+/// The list membership predicate is bounded above by the maximum.
+theorem list_max_contains_upper_bound[T: LinearOrder](head: T, tail: List[T]) {
+    lib(order_interval).is_upper_bound(List.cons(head, tail).contains, list_max(head, tail))
+} by {
+    list_max_is_upper_bound(head, tail)
+    upper_bound_imp_contains_upper_bound(List.cons(head, tail), list_max(head, tail))
+}
+
+/// The list membership predicate is bounded above.
+theorem list_max_contains_bounded_above[T: LinearOrder](head: T, tail: List[T]) {
+    lib(order_interval).is_bounded_above(List.cons(head, tail).contains)
+} by {
+    list_max_contains_upper_bound(head, tail)
+    lib(order_interval).upper_bound_imp_bounded_above(List.cons(head, tail).contains,
+        list_max(head, tail))
+}
+
+/// Every element of a non-empty list lies between the list minimum and maximum.
+theorem list_contains_closed_interval_min_max[T: LinearOrder](head: T, tail: List[T], item: T) {
+    List.cons(head, tail).contains(item) implies
+    closed_interval(list_min(head, tail), list_max(head, tail), item)
+} by {
+    if List.cons(head, tail).contains(item) {
+        list_min_max_interval_bound(head, tail)
+        interval_bound_contains(List.cons(head, tail), list_min(head, tail), list_max(head, tail), item)
+        closed_interval(list_min(head, tail), list_max(head, tail), item)
+    }
+}
+
+/// A non-empty list is interval-bounded by its minimum and maximum.
+theorem list_has_interval_bound[T: LinearOrder](head: T, tail: List[T]) {
+    exists(lower: T, upper: T) {
+        is_interval_bound(List.cons(head, tail), lower, upper)
+    }
+} by {
+    list_min_max_interval_bound(head, tail)
+    exists(lower: T, upper: T) {
+        lower = list_min(head, tail) and
+        upper = list_max(head, tail) and
+        is_interval_bound(List.cons(head, tail), lower, upper)
+    }
 }


### PR DESCRIPTION
## Summary
- add interval-bound predicates for lists and bridges from list bounds to `order_interval` predicate boundedness
- prove non-empty list min/max closed-interval and boundedness corollaries
- update the translate-mathlib order-operations roadmap

## Test Plan
- `acorn check`

Stacked on #233 (`translate-mathlib-chunk-20260430-222339`).
