### PR TITLE
feat: add order isomorphism basics

### DIFF
--- a/build/order_iso.jsonl
+++ b/build/order_iso.jsonl
@@ -1,0 +1,163 @@
+{"goal":"is_order_iso_pair[A, B](f, g) = (forall(x0: A) { g(f(x0)) = x0 } and forall(x1: B) { f(g(x1)) = x1 } and is_order_embedding[A, B](f) and is_order_embedding[B, A](g))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1) and is_order_embedding[T1, T0](x0)) = is_order_iso_pair[T0, T1](x1, x0) }[A, B](g, f)"]}
+{"goal":"g(f(a)) = a","proof":["(forall(x0: A) { g(f(x0)) = x0 } and forall(x1: B) { f(g(x1)) = x1 } and is_order_embedding[A, B](f))","(forall(x2: A) { g(f(x2)) = x2 } = true)","function(x0: A) { g(f(x0)) = x0 }(a)"]}
+{"goal":"order_iso_pair_left_inverse","proof":[]}
+{"goal":"is_order_iso_pair[A, B](f, g) = (forall(x0: A) { g(f(x0)) = x0 } and forall(x1: B) { f(g(x1)) = x1 } and is_order_embedding[A, B](f) and is_order_embedding[B, A](g))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1) and is_order_embedding[T1, T0](x0)) = is_order_iso_pair[T0, T1](x1, x0) }[A, B](g, f)"]}
+{"goal":"f(g(b)) = b","proof":["(forall(x0: A) { g(f(x0)) = x0 } and forall(x1: B) { f(g(x1)) = x1 } and is_order_embedding[A, B](f))","(forall(x2: B) { f(g(x2)) = x2 } = true)","function(x0: B) { f(g(x0)) = x0 }(b)"]}
+{"goal":"order_iso_pair_right_inverse","proof":[]}
+{"goal":"is_order_iso_pair[A, B](f, g) = (forall(x0: A) { g(f(x0)) = x0 } and forall(x1: B) { f(g(x1)) = x1 } and is_order_embedding[A, B](f) and is_order_embedding[B, A](g))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1) and is_order_embedding[T1, T0](x0)) = is_order_iso_pair[T0, T1](x1, x0) }[A, B](g, f)"]}
+{"goal":"is_order_embedding[A, B](f)","proof":[]}
+{"goal":"order_iso_pair_map_is_order_embedding","proof":[]}
+{"goal":"is_order_iso_pair[A, B](f, g) = (forall(x0: A) { g(f(x0)) = x0 } and forall(x1: B) { f(g(x1)) = x1 } and is_order_embedding[A, B](f) and is_order_embedding[B, A](g))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1) and is_order_embedding[T1, T0](x0)) = is_order_iso_pair[T0, T1](x1, x0) }[A, B](g, f)"]}
+{"goal":"is_order_embedding[B, A](g)","proof":[]}
+{"goal":"order_iso_pair_inv_is_order_embedding","proof":[]}
+{"goal":"is_order_embedding[A, B](f)","proof":[]}
+{"goal":"is_order_embedding[B, A](g)","proof":[]}
+{"goal":"f(g(x)) = x","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T1 -> T0, x2: T1) { not is_order_iso_pair[T0, T1](x0, x1) or x2 = x0(x1(x2)) }[A, B](f, g, x)"]}
+{"goal":"g(f(y)) = y","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T1 -> T0, x2: T0) { not is_order_iso_pair[T0, T1](x0, x1) or x2 = x1(x0(x2)) }[A, B](f, g, y)"]}
+{"goal":"order_iso_pair_inverse","proof":[]}
+{"goal":"is_order_embedding[A, B](f)","proof":[]}
+{"goal":"is_order_embedding[B, C](u)","proof":[]}
+{"goal":"is_order_embedding[A, C](compose[A, B, C](u, f))","proof":[]}
+{"goal":"is_order_embedding[B, A](g)","proof":[]}
+{"goal":"is_order_embedding[C, B](v)","proof":[]}
+{"goal":"is_order_embedding[C, A](compose[C, B, A](g, v))","proof":[]}
+{"goal":"compose[C, B, A](g, v, compose[A, B, C](u, f, a)) = g(v(compose[A, B, C](u, f, a)))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[C, B, A](g, v, compose[A, B, C](u, f, a))"]}
+{"goal":"compose[A, B, C](u, f, a) = u(f(a))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](u, f, a)"]}
+{"goal":"v(u(f(a))) = f(a)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T1 -> T0, x2: T0) { not is_order_iso_pair[T0, T1](x0, x1) or x2 = x1(x0(x2)) }[B, C](u, v, f(a))"]}
+{"goal":"g(f(a)) = a","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T1 -> T0, x2: T0) { not is_order_iso_pair[T0, T1](x0, x1) or x2 = x1(x0(x2)) }[A, B](f, g, a)"]}
+{"goal":"compose[C, B, A](g, v, compose[A, B, C](u, f, a)) = a","proof":[]}
+{"goal":"compose[A, B, C](u, f, compose[C, B, A](g, v, c)) = u(f(compose[C, B, A](g, v, c)))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](u, f, compose[C, B, A](g, v, c))"]}
+{"goal":"compose[C, B, A](g, v, c) = g(v(c))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[C, B, A](g, v, c)"]}
+{"goal":"f(g(v(c))) = v(c)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T1 -> T0, x2: T1) { not is_order_iso_pair[T0, T1](x0, x1) or x2 = x0(x1(x2)) }[A, B](f, g, v(c))"]}
+{"goal":"u(v(c)) = c","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T1 -> T0, x2: T1) { not is_order_iso_pair[T0, T1](x0, x1) or x2 = x0(x1(x2)) }[B, C](u, v, c)"]}
+{"goal":"compose[A, B, C](u, f, compose[C, B, A](g, v, c)) = c","proof":[]}
+{"goal":"compose[C, B, A](g, v, compose[A, B, C](u, f, a)) = a","proof":["function(x0: A) { compose[C, B, A](g, v, compose[A, B, C](u, f, x0)) = x0 }(a)"]}
+{"goal":"compose[A, B, C](u, f, compose[C, B, A](g, v, c)) = c","proof":["function(x0: C) { compose[A, B, C](u, f, compose[C, B, A](g, v, x0)) = x0 }(c)"]}
+{"goal":"compose_order_iso_pair","proof":[]}
+{"goal":"order_iso_new_map","proof":["let w0: A satisfy { f(w0) != e.map(w0) }","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T0 -> T1, x2: T1 -> T0, x3: T0) { Option.some[OrderIso[T0, T1]](x0) != OrderIso.new[T0, T1](x1, x2) or x0.map(x3) = x1(x3) }[A, B](e, f, g, w0)"]}
+{"goal":"order_iso_new_inv","proof":["let w0: B satisfy { g(w0) != e.inv(w0) }","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T0 -> T1, x2: T1 -> T0, x3: T1) { Option.some[OrderIso[T0, T1]](x0) != OrderIso.new[T0, T1](x1, x2) or x0.inv(x3) = x2(x3) }[A, B](e, f, g, w0)"]}
+{"goal":"order_iso_new_self","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { OrderIso.new[T0, T1](x0.map, x0.inv) = Option.some[OrderIso[T0, T1]](x0) }[A, B](e)"]}
+{"goal":"order_iso_some_injective","proof":["function[T0](x0: T0, x1: T0) { Option.some[T0](x0) != Option.some[T0](x1) or x0 = x1 }[OrderIso[A, B]](e, h)"]}
+{"goal":"OrderIso.new[A, B](e.map, e.inv) = Option.some(e)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { OrderIso.new[T0, T1](x0.map, x0.inv) = Option.some[OrderIso[T0, T1]](x0) }[A, B](e)"]}
+{"goal":"OrderIso.new[A, B](h.map, h.inv) = Option.some(h)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { OrderIso.new[T0, T1](x0.map, x0.inv) = Option.some[OrderIso[T0, T1]](x0) }[A, B](h)"]}
+{"goal":"Option.some(e) = Option.some(h)","proof":[]}
+{"goal":"order_iso_ext","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { OrderIso.new[T0, T1](x0.map, x0.inv) = Option.some[OrderIso[T0, T1]](x0) }[A, B](e)","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { OrderIso.new[T0, T1](x0.map, x0.inv) = Option.some[OrderIso[T0, T1]](x0) }[A, B](h)"]}
+{"goal":"order_iso_eq_map","proof":[]}
+{"goal":"order_iso_eq_inv","proof":[]}
+{"goal":"OrderIso.constraint[A, B](e.map, e.inv)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { is_order_iso_pair[T0, T1](x0.map, x0.inv) }[A, B](e)"]}
+{"goal":"is_order_iso_pair[A, B](e.map, e.inv)","proof":[]}
+{"goal":"order_iso_left_inverse","proof":[]}
+{"goal":"OrderIso.constraint[A, B](e.map, e.inv)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { is_order_iso_pair[T0, T1](x0.map, x0.inv) }[A, B](e)"]}
+{"goal":"is_order_iso_pair[A, B](e.map, e.inv)","proof":[]}
+{"goal":"order_iso_right_inverse","proof":[]}
+{"goal":"OrderIso.constraint[A, B](e.map, e.inv)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { is_order_iso_pair[T0, T1](x0.map, x0.inv) }[A, B](e)"]}
+{"goal":"is_order_iso_pair[A, B](e.map, e.inv)","proof":[]}
+{"goal":"order_iso_map_is_order_embedding","proof":[]}
+{"goal":"e.map(e.inv(x)) = x","proof":[]}
+{"goal":"e.map(e.inv(y)) = y","proof":[]}
+{"goal":"e.map(e.inv(x)) <= e.map(e.inv(y))","proof":[]}
+{"goal":"x <= y","proof":[]}
+{"goal":"e.map(e.inv(x)) <= e.map(e.inv(y))","proof":[]}
+{"goal":"e.inv(x) <= e.inv(y)","proof":[]}
+{"goal":"e.inv(x) <= e.inv(y) = x <= y","proof":[]}
+{"goal":"order_iso_inv_is_order_embedding","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { forall(x1: T0, x2: T0) { x1 <= x2 = x0(x1) <= x0(x2) } = is_order_embedding[T0, T1](x0) }[B, A](e.inv)","let w0: B satisfy { exists(k0: B) { w0 <= k0 != e.inv(w0) <= e.inv(k0) } }","let w1: B satisfy { w0 <= w1 != e.inv(w0) <= e.inv(w1) }","function(x0: B, x1: B) { e.inv(x0) <= e.inv(x1) = x0 <= x1 }(w0, w1)"]}
+{"goal":"x = y","proof":[]}
+{"goal":"order_iso_map_is_injective","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1) { not is_order_embedding[T0, T1](x0) or is_injective_fn[T0, T1](x0) }[A, B](identity_fn(e).map)","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { is_order_embedding[T0, T1](x0.map) }[A, B](identity_fn(e))","function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[OrderIso[A, B]](e)"]}
+{"goal":"exists(k0: A) { k0 = e.inv(y) and e.map(k0) = y }","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T1) { x0.map(x0.inv(x1)) = x1 }[A, B](e, y)"]}
+{"goal":"order_iso_map_is_surjective","proof":["function[T0, T1](x0: T1 -> T0) { forall(x1: T0) { exists(k0: T1) { x0(k0) = x1 } } = is_surjective_fn[T1, T0](x0) }[B, A](e.map)","let w0: B satisfy { forall(x0: A) { e.map(x0) != w0 } }","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T1) { x0.map(x0.inv(x1)) = x1 }[A, B](e, w0)","(forall(x1: A) { e.map(x1) != w0 } = true)","function(x0: A) { e.map(x0) != w0 }(e.inv(w0))"]}
+{"goal":"is_injective_fn[A, B](e.map)","proof":[]}
+{"goal":"is_surjective_fn[A, B](e.map)","proof":[]}
+{"goal":"is_bijection_fn[A, B](e.map)","proof":["function[T0, T1](x0: T0 -> T1) { (is_injective_fn[T0, T1](x0) and is_surjective_fn[T0, T1](x0)) = is_bijection_fn[T0, T1](x0) }[A, B](e.map)"]}
+{"goal":"order_iso_map_is_bijection","proof":[]}
+{"goal":"x = y","proof":[]}
+{"goal":"order_iso_inv_is_injective","proof":["function[T0, T1](x0: T0 -> T1) { forall(x1: T0, x2: T0) { x0(x2) != x0(x1) or x2 = x1 } = is_injective_fn[T0, T1](x0) }[B, A](e.inv)","let w0: B satisfy { exists(k0: B) { e.inv(k0) = e.inv(w0) and k0 != w0 } }","let w1: B satisfy { e.inv(w1) = e.inv(w0) and w1 != w0 }","function(x0: B, x1: B) { e.inv(x0) != e.inv(x1) or x0 = x1 }(w0, w1)"]}
+{"goal":"exists(k0: B) { k0 = e.map(x) and e.inv(k0) = x }","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T0) { x0.inv(x0.map(x1)) = x1 }[A, B](e, x)"]}
+{"goal":"order_iso_inv_is_surjective","proof":["function[T0, T1](x0: T1 -> T0) { forall(x1: T0) { exists(k0: T1) { x0(k0) = x1 } } = is_surjective_fn[T1, T0](x0) }[A, B](e.inv)","let w0: A satisfy { forall(x0: B) { e.inv(x0) != w0 } }","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T0) { x0.inv(x0.map(x1)) = x1 }[A, B](e, w0)","(forall(x1: B) { e.inv(x1) != w0 } = true)","function(x0: B) { e.inv(x0) != w0 }(e.map(w0))"]}
+{"goal":"is_injective_fn[B, A](e.inv)","proof":[]}
+{"goal":"is_surjective_fn[B, A](e.inv)","proof":[]}
+{"goal":"is_bijection_fn[B, A](e.inv)","proof":["function[T0, T1](x0: T0 -> T1) { (is_injective_fn[T0, T1](x0) and is_surjective_fn[T0, T1](x0)) = is_bijection_fn[T0, T1](x0) }[B, A](e.inv)"]}
+{"goal":"order_iso_inv_is_bijection","proof":[]}
+{"goal":"e.map(x) <= e.map(y)","proof":[]}
+{"goal":"order_iso_apply_le","proof":[]}
+{"goal":"x <= y","proof":[]}
+{"goal":"order_iso_reflects_le","proof":[]}
+{"goal":"x <= y","proof":[]}
+{"goal":"e.map(x) <= e.map(y)","proof":[]}
+{"goal":"e.map(x) <= e.map(y) = x <= y","proof":[]}
+{"goal":"order_iso_le_iff_le","proof":[]}
+{"goal":"e.inv(x) <= e.inv(y)","proof":[]}
+{"goal":"order_iso_inv_apply_le","proof":[]}
+{"goal":"x <= y","proof":[]}
+{"goal":"order_iso_inv_reflects_le","proof":[]}
+{"goal":"x <= y","proof":[]}
+{"goal":"e.inv(x) <= e.inv(y)","proof":[]}
+{"goal":"e.inv(x) <= e.inv(y) = x <= y","proof":[]}
+{"goal":"order_iso_inv_le_iff_le","proof":[]}
+{"goal":"is_order_embedding[A, A](identity_fn[A])","proof":[]}
+{"goal":"identity_fn(identity_fn(a)) = a","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[A](a)"]}
+{"goal":"is_order_iso_pair[A, A](identity_fn[A], identity_fn[A])","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) = is_order_iso_pair[T0, T1](x1, x0) }[A, A](identity_fn[A], identity_fn[A])","function[T0: PartialOrder] { is_order_embedding[T0, T0](identity_fn[T0]) }[A]","not (forall(x0: A) { identity_fn(identity_fn(x0)) = x0 } and forall(x1: A) { identity_fn(identity_fn(x1)) = x1 } and is_order_embedding[A, A](identity_fn[A]))","not (forall(x2: A) { identity_fn(identity_fn(x2)) = x2 } and forall(x3: A) { identity_fn(identity_fn(x3)) = x3 })","let w0: A satisfy { identity_fn(identity_fn(w0)) != w0 }","function(x0: A) { identity_fn(identity_fn(x0)) = x0 }(w0)"]}
+{"goal":"exists(k0: OrderIso[A, A]) { OrderIso.new[A, A](identity_fn[A], identity_fn[A]) = Option.some(k0) }","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T1 -> T0) { not OrderIso.constraint[T0, T1](x0, x1) or exists(k0: OrderIso[T0, T1]) { Option.some[OrderIso[T0, T1]](k0) = OrderIso.new[T0, T1](x0, x1) } }[A, A](identity_fn[A], identity_fn[A])"]}
+{"goal":"e.map = identity_fn[A]","proof":[]}
+{"goal":"e.inv = identity_fn[A]","proof":[]}
+{"goal":"exists(k0: OrderIso[A, A]) { k0.map = identity_fn[A] and k0.inv = identity_fn[A] }","proof":["function(x0: OrderIso[A, A]) { not (identity_fn[A] = x0.map and identity_fn[A] = x0.inv) }(e)"]}
+{"goal":"identity_order_iso_map","proof":["function[T0: PartialOrder](x0: T0) { identity_fn[T0] = identity_order_iso[T0](x0).map and identity_fn[T0] = identity_order_iso[T0](x0).inv }[A](anchor)"]}
+{"goal":"identity_order_iso_inv","proof":["function[T0: PartialOrder](x0: T0) { identity_fn[T0] = identity_order_iso[T0](x0).map and identity_fn[T0] = identity_order_iso[T0](x0).inv }[A](anchor)"]}
+{"goal":"OrderIso.constraint[A, B](e.map, e.inv)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { is_order_iso_pair[T0, T1](x0.map, x0.inv) }[A, B](e)"]}
+{"goal":"is_order_iso_pair[A, B](e.map, e.inv)","proof":[]}
+{"goal":"is_order_iso_pair[B, A](e.inv, e.map)","proof":[]}
+{"goal":"exists(k0: OrderIso[B, A]) { OrderIso.new[B, A](e.inv, e.map) = Option.some(k0) }","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T1 -> T0) { not OrderIso.constraint[T0, T1](x0, x1) or exists(k0: OrderIso[T0, T1]) { Option.some[OrderIso[T0, T1]](k0) = OrderIso.new[T0, T1](x0, x1) } }[B, A](e.inv, e.map)"]}
+{"goal":"h.map = e.inv","proof":[]}
+{"goal":"h.inv = e.map","proof":[]}
+{"goal":"exists(k0: OrderIso[B, A]) { k0.map = e.inv and k0.inv = e.map }","proof":["function(x0: OrderIso[B, A]) { not (e.inv = x0.map and x0.inv = e.map) }(h)"]}
+{"goal":"inverse_order_iso_map","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T1, T0]) { x0.inv = inverse_order_iso[T1, T0](x0).map and inverse_order_iso[T1, T0](x0).inv = x0.map }[B, A](e)"]}
+{"goal":"inverse_order_iso_inv","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T1, T0]) { x0.inv = inverse_order_iso[T1, T0](x0).map and inverse_order_iso[T1, T0](x0).inv = x0.map }[B, A](e)"]}
+{"goal":"inverse_order_iso[A, B](e).map = e.inv","proof":[]}
+{"goal":"inverse_order_iso[A, B](e).map(e.map(x)) = x","proof":[]}
+{"goal":"inverse_order_iso_apply_image","proof":[]}
+{"goal":"inverse_order_iso[A, B](e).map = e.inv","proof":[]}
+{"goal":"e.map(inverse_order_iso[A, B](e).map(y)) = y","proof":[]}
+{"goal":"order_iso_apply_inverse","proof":[]}
+{"goal":"OrderIso.constraint[B, C](e.map, e.inv)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { is_order_iso_pair[T0, T1](x0.map, x0.inv) }[B, C](e)"]}
+{"goal":"is_order_iso_pair[B, C](e.map, e.inv)","proof":[]}
+{"goal":"OrderIso.constraint[A, B](h.map, h.inv)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { is_order_iso_pair[T0, T1](x0.map, x0.inv) }[A, B](h)"]}
+{"goal":"is_order_iso_pair[A, B](h.map, h.inv)","proof":[]}
+{"goal":"is_order_iso_pair[A, C](compose[A, B, C](e.map, h.map), compose[C, B, A](h.inv, e.inv))","proof":[]}
+{"goal":"exists(k0: OrderIso[A, C]) { OrderIso.new[A, C](compose[A, B, C](e.map, h.map), compose[C, B, A](h.inv, e.inv)) = Option.some(k0) }","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T0 -> T1, x1: T1 -> T0) { not OrderIso.constraint[T0, T1](x0, x1) or exists(k0: OrderIso[T0, T1]) { Option.some[OrderIso[T0, T1]](k0) = OrderIso.new[T0, T1](x0, x1) } }[A, C](compose[A, B, C](e.map, h.map), compose[C, B, A](h.inv, e.inv))"]}
+{"goal":"k.map = compose[A, B, C](e.map, h.map)","proof":[]}
+{"goal":"k.inv = compose[C, B, A](h.inv, e.inv)","proof":[]}
+{"goal":"exists(k0: OrderIso[A, C]) { k0.map = compose[A, B, C](e.map, h.map) and k0.inv = compose[C, B, A](h.inv, e.inv) }","proof":["function(x0: OrderIso[A, C]) { not (x0.map = compose[A, B, C](e.map, h.map) and x0.inv = compose[C, B, A](h.inv, e.inv)) }(k)"]}
+{"goal":"compose_order_iso_map","proof":["function[T0: PartialOrder, T1: PartialOrder, T2: PartialOrder](x0: OrderIso[T2, T1], x1: OrderIso[T0, T2]) { compose_order_iso[T0, T2, T1](x0, x1).map = compose[T0, T2, T1](x0.map, x1.map) and compose_order_iso[T0, T2, T1](x0, x1).inv = compose[T1, T2, T0](x1.inv, x0.inv) }[A, C, B](e, h)"]}
+{"goal":"compose_order_iso_inv","proof":["function[T0: PartialOrder, T1: PartialOrder, T2: PartialOrder](x0: OrderIso[T2, T1], x1: OrderIso[T0, T2]) { compose_order_iso[T0, T2, T1](x0, x1).map = compose[T0, T2, T1](x0.map, x1.map) and compose_order_iso[T0, T2, T1](x0, x1).inv = compose[T1, T2, T0](x1.inv, x0.inv) }[A, C, B](e, h)"]}
+{"goal":"is_order_iso_pair[B, A](g, f) = (forall(x0: B) { f(g(x0)) = x0 } and forall(x1: A) { g(f(x1)) = x1 } and is_order_embedding[B, A](g) and is_order_embedding[A, B](f))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1) and is_order_embedding[T1, T0](x0)) = is_order_iso_pair[T0, T1](x1, x0) }[B, A](f, g)"]}
+{"goal":"f(g(y)) = y","proof":[]}
+{"goal":"is_order_embedding[B, A](e.inv)","proof":[]}
+{"goal":"is_order_embedding[A, B](e.map)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { forall(x1: T0) { x0.inv(x0.map(x1)) = x1 } and forall(x2: T1) { x0.map(x0.inv(x2)) = x2 } and is_order_embedding[T0, T1](x0.map) }[A, B](e)","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { is_order_embedding[T0, T1](x0.map) }[A, B](e)"]}
+{"goal":"is_order_iso_pair[A, B](f, g) = (forall(x0: A) { g(f(x0)) = x0 } and forall(x1: B) { f(g(x1)) = x1 } and is_order_embedding[A, B](f))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) = is_order_iso_pair[T0, T1](x1, x0) }[A, B](g, f)"]}
+{"goal":"is_order_iso_pair[A, B](f, g) = (forall(x0: A) { g(f(x0)) = x0 } and forall(x1: B) { f(g(x1)) = x1 } and is_order_embedding[A, B](f))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) = is_order_iso_pair[T0, T1](x1, x0) }[A, B](g, f)"]}
+{"goal":"is_order_iso_pair[A, B](f, g) = (forall(x0: A) { g(f(x0)) = x0 } and forall(x1: B) { f(g(x1)) = x1 } and is_order_embedding[A, B](f))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) = is_order_iso_pair[T0, T1](x1, x0) }[A, B](g, f)"]}
+{"goal":"e.inv(e.map(h.map(a))) = h.map(a)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T0) { x0.inv(x0.map(x1)) = x1 }[B, C](e, h.map(a))"]}
+{"goal":"compose[C, B, A](h.inv, e.inv, compose[A, B, C](e.map, h.map, a)) = h.inv(e.inv(compose[A, B, C](e.map, h.map, a)))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[C, B, A](h.inv, e.inv, compose[A, B, C](e.map, h.map, a))"]}
+{"goal":"f(g(y)) <= f(g(z))","proof":[]}
+{"goal":"f(g(y)) <= f(g(z))","proof":[]}
+{"goal":"OrderIso.constraint[A, B](e.map, e.inv)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) = OrderIso.constraint[T0, T1](x1, x0) }[A, B](e.inv, e.map)","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { forall(x1: T0) { x0.inv(x0.map(x1)) = x1 } and forall(x2: T1) { x0.map(x0.inv(x2)) = x2 } and is_order_embedding[T0, T1](x0.map) }[A, B](e)","function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { not (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) or OrderIso.constraint[T0, T1](x1, x0) }[A, B](e.inv, e.map)"]}
+{"goal":"OrderIso.constraint[A, B](e.map, e.inv)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) = OrderIso.constraint[T0, T1](x1, x0) }[A, B](e.inv, e.map)","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { forall(x1: T0) { x0.inv(x0.map(x1)) = x1 } and forall(x2: T1) { x0.map(x0.inv(x2)) = x2 } and is_order_embedding[T0, T1](x0.map) }[A, B](e)","function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { not (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) or OrderIso.constraint[T0, T1](x1, x0) }[A, B](e.inv, e.map)"]}
+{"goal":"OrderIso.constraint[A, B](e.map, e.inv)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) = OrderIso.constraint[T0, T1](x1, x0) }[A, B](e.inv, e.map)","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1]) { forall(x1: T0) { x0.inv(x0.map(x1)) = x1 } and forall(x2: T1) { x0.map(x0.inv(x2)) = x2 } and is_order_embedding[T0, T1](x0.map) }[A, B](e)","function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { not (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) or OrderIso.constraint[T0, T1](x1, x0) }[A, B](e.inv, e.map)"]}
+{"goal":"y <= z","proof":[]}
+{"goal":"compose[C, B, A](h.inv, e.inv, compose[A, B, C](e.map, h.map, a)) = a","proof":[]}
+{"goal":"order_iso_map_is_order_embedding","proof":[]}
+{"goal":"is_order_iso_pair[A, C](compose[A, B, C](u, f), compose[C, B, A](g, v)) = (forall(x0: A) { compose[C, B, A](g, v, compose[A, B, C](u, f, x0)) = x0 } and forall(x1: C) { compose[A, B, C](u, f, compose[C, B, A](g, v, x1)) = x1 } and is_order_embedding[A, C](compose[A, B, C](u, f)))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) = is_order_iso_pair[T0, T1](x1, x0) }[A, C](compose[C, B, A](g, v), compose[A, B, C](u, f))"]}
+{"goal":"is_order_iso_pair[A, C](compose[A, B, C](u, f), compose[C, B, A](g, v)) = (forall(x0: A) { compose[C, B, A](g, v, compose[A, B, C](u, f, x0)) = x0 } and forall(x1: C) { compose[A, B, C](u, f, compose[C, B, A](g, v, x1)) = x1 } and is_order_embedding[A, C](compose[A, B, C](u, f)) and is_order_embedding[C, A](compose[C, B, A](g, v)))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1) and is_order_embedding[T1, T0](x0)) = is_order_iso_pair[T0, T1](x1, x0) }[A, C](compose[C, B, A](g, v), compose[A, B, C](u, f))"]}
+{"goal":"is_order_iso_pair[B, A](g, f) = (forall(x0: B) { f(g(x0)) = x0 } and forall(x1: A) { g(f(x1)) = x1 } and is_order_embedding[B, A](g))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) = is_order_iso_pair[T0, T1](x1, x0) }[B, A](f, g)"]}
+{"goal":"compose[A, B, C](e.map, h.map, a) = e.map(h.map(a))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](e.map, h.map, a)"]}
+{"goal":"g(y) <= g(z) = y <= z","proof":[]}
+{"goal":"e.inv(e.map(a)) = a","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T0) { x0.inv(x0.map(x1)) = x1 }[A, B](e, a)"]}
+{"goal":"compose[A, B, C](e.map, h.map, compose[C, B, A](h.inv, e.inv, c)) = e.map(h.map(compose[C, B, A](h.inv, e.inv, c)))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[A, B, C](e.map, h.map, compose[C, B, A](h.inv, e.inv, c))"]}
+{"goal":"e.map(e.inv(c)) = c","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T1) { x0.map(inverse_order_iso[T0, T1](x0).map(x1)) = x1 }[B, C](e, c)","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T1, T0], x1: T0) { inverse_order_iso[T1, T0](x0).map(x1) = x0.inv(x1) }[C, B](e, c)"]}
+{"goal":"e.map(e.inv(b)) = b","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T1) { x0.map(x0.inv(x1)) = x1 }[A, B](e, b)"]}
+{"goal":"g(y) <= g(z)","proof":[]}
+{"goal":"is_order_embedding[A, C](compose[A, B, C](e.map, h.map))","proof":[]}
+{"goal":"f(g(z)) = z","proof":[]}
+{"goal":"compose[A, B, C](e.map, h.map, compose[C, B, A](h.inv, e.inv, c)) = c","proof":[]}
+{"goal":"h.inv(h.map(a)) = a","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T0) { x0.inv(x0.map(x1)) = x1 }[A, B](h, a)"]}
+{"goal":"compose[C, B, A](h.inv, e.inv, c) = h.inv(e.inv(c))","proof":["function[T0, T1, T2](x0: T1 -> T2, x1: T0 -> T1, x2: T0) { compose[T0, T1, T2](x0, x1, x2) = x0(x1(x2)) }[C, B, A](h.inv, e.inv, c)"]}
+{"goal":"h.map(h.inv(e.inv(c))) = e.inv(c)","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T1) { x0.map(inverse_order_iso[T0, T1](x0).map(x1)) = x1 }[A, B](h, e.inv(c))","function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T1, T0], x1: T0) { inverse_order_iso[T1, T0](x0).map(x1) = x0.inv(x1) }[B, A](h, e.inv(c))"]}

--- a/projects/translate-mathlib/order-theory/order-isomorphisms/todo.md
+++ b/projects/translate-mathlib/order-theory/order-isomorphisms/todo.md
@@ -2,13 +2,15 @@
 
 Goal: make equivalent ordered structures interchangeable without ad hoc transport code.
 
-- [ ] Define order isomorphisms
-- [ ] Add inverse, composition, and identity order isomorphisms
+Status:
+
+- `src/order_iso.ac` now defines order-isomorphism pairs and bundled `OrderIso` values, with projection, extensionality, inverse-law, embedding, bijection, order-reflection, and identity-isomorphism lemmas.
+
+- [ ] Add inverse and composition order isomorphisms
 - [ ] Add coercions or wrappers for using order isomorphisms as functions
 - [ ] Add transport lemmas for intervals and bounds under order isomorphisms
 - [ ] Add transport of lattice structure across order isomorphisms
 - [ ] Connect order isomorphisms with algebraic equivalences in ordered algebra
-- [ ] Add extensionality lemmas for order isomorphisms
 - [ ] Add order duality as a standard isomorphism pattern
 - [ ] Support order isomorphisms for product and function spaces
 - [ ] Refactor representative transport-heavy proofs to use the new API

--- a/src/order_iso.ac
+++ b/src/order_iso.ac
@@ -1,0 +1,348 @@
+/// Order isomorphisms between partially ordered types.
+
+from functions import identity_fn, is_injective_fn, is_surjective_fn, is_bijection_fn
+from order import PartialOrder
+from order_maps import is_order_embedding, order_embedding_apply_le,
+    order_embedding_reflects_lte, identity_is_order_embedding
+
+/// True if two maps are inverse order-preserving maps.
+define is_order_iso_pair[A: PartialOrder, B: PartialOrder](f: A -> B, g: B -> A) -> Bool {
+    forall(a: A) {
+        g(f(a)) = a
+    } and forall(b: B) {
+        f(g(b)) = b
+    } and is_order_embedding(f) and is_order_embedding(g)
+}
+
+/// An order isomorphism pair has a left inverse.
+theorem order_iso_pair_left_inverse[A: PartialOrder, B: PartialOrder](f: A -> B, g: B -> A, a: A) {
+    is_order_iso_pair(f, g) implies g(f(a)) = a
+} by {
+    if is_order_iso_pair(f, g) {
+        is_order_iso_pair(f, g) = (forall(x: A) {
+            g(f(x)) = x
+        } and forall(y: B) {
+            f(g(y)) = y
+        } and is_order_embedding(f) and is_order_embedding(g))
+        g(f(a)) = a
+    }
+}
+
+/// An order isomorphism pair has a right inverse.
+theorem order_iso_pair_right_inverse[A: PartialOrder, B: PartialOrder](f: A -> B, g: B -> A, b: B) {
+    is_order_iso_pair(f, g) implies f(g(b)) = b
+} by {
+    if is_order_iso_pair(f, g) {
+        is_order_iso_pair(f, g) = (forall(x: A) {
+            g(f(x)) = x
+        } and forall(y: B) {
+            f(g(y)) = y
+        } and is_order_embedding(f) and is_order_embedding(g))
+        f(g(b)) = b
+    }
+}
+
+/// The forward map of an order isomorphism pair is an order embedding.
+theorem order_iso_pair_map_is_order_embedding[A: PartialOrder, B: PartialOrder](f: A -> B, g: B -> A) {
+    is_order_iso_pair(f, g) implies is_order_embedding(f)
+} by {
+    if is_order_iso_pair(f, g) {
+        is_order_iso_pair(f, g) = (forall(x: A) {
+            g(f(x)) = x
+        } and forall(y: B) {
+            f(g(y)) = y
+        } and is_order_embedding(f) and is_order_embedding(g))
+        is_order_embedding(f)
+    }
+}
+
+/// The inverse map of an order isomorphism pair is an order embedding.
+theorem order_iso_pair_inv_is_order_embedding[A: PartialOrder, B: PartialOrder](f: A -> B, g: B -> A) {
+    is_order_iso_pair(f, g) implies is_order_embedding(g)
+} by {
+    if is_order_iso_pair(f, g) {
+        is_order_iso_pair(f, g) = (forall(x: A) {
+            g(f(x)) = x
+        } and forall(y: B) {
+            f(g(y)) = y
+        } and is_order_embedding(f) and is_order_embedding(g))
+        is_order_embedding(g)
+    }
+}
+
+/// An order isomorphism with explicit inverse data.
+structure OrderIso[A: PartialOrder, B: PartialOrder] {
+    /// The order-preserving map.
+    map: A -> B
+
+    /// The inverse order-preserving map.
+    inv: B -> A
+} constraint {
+    is_order_iso_pair(map, inv)
+}
+
+/// Construction of an order isomorphism remembers the underlying map.
+theorem order_iso_new_map[A: PartialOrder, B: PartialOrder](f: A -> B, g: B -> A, e: OrderIso[A, B]) {
+    OrderIso[A, B].new(f, g) = Option.some(e) implies e.map = f
+}
+
+/// Construction of an order isomorphism remembers the inverse map.
+theorem order_iso_new_inv[A: PartialOrder, B: PartialOrder](f: A -> B, g: B -> A, e: OrderIso[A, B]) {
+    OrderIso[A, B].new(f, g) = Option.some(e) implies e.inv = g
+}
+
+/// Every order isomorphism is reconstructed from its maps.
+theorem order_iso_new_self[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B]) {
+    OrderIso[A, B].new(e.map, e.inv) = Option.some(e)
+}
+
+/// Equality of options containing order isomorphisms is equality of order isomorphisms.
+theorem order_iso_some_injective[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], h: OrderIso[A, B]) {
+    Option.some(e) = Option.some(h) implies e = h
+}
+
+/// Order isomorphisms are equal when their maps and inverse maps are equal.
+theorem order_iso_ext[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], h: OrderIso[A, B]) {
+    e.map = h.map and e.inv = h.inv implies e = h
+} by {
+    if e.map = h.map and e.inv = h.inv {
+        OrderIso[A, B].new(e.map, e.inv) = Option.some(e)
+        OrderIso[A, B].new(h.map, h.inv) = Option.some(h)
+        Option.some(e) = Option.some(h)
+        order_iso_some_injective(e, h)
+    }
+}
+
+/// Equal order isomorphisms have equal underlying maps.
+theorem order_iso_eq_map[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], h: OrderIso[A, B]) {
+    e = h implies e.map = h.map
+}
+
+/// Equal order isomorphisms have equal inverse maps.
+theorem order_iso_eq_inv[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], h: OrderIso[A, B]) {
+    e = h implies e.inv = h.inv
+}
+
+/// The inverse map is a left inverse of the map.
+theorem order_iso_left_inverse[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], a: A) {
+    e.inv(e.map(a)) = a
+} by {
+    OrderIso[A, B].constraint(e.map, e.inv)
+    is_order_iso_pair(e.map, e.inv)
+    order_iso_pair_left_inverse(e.map, e.inv, a)
+}
+
+/// The inverse map is a right inverse of the map.
+theorem order_iso_right_inverse[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], b: B) {
+    e.map(e.inv(b)) = b
+} by {
+    OrderIso[A, B].constraint(e.map, e.inv)
+    is_order_iso_pair(e.map, e.inv)
+    order_iso_pair_right_inverse(e.map, e.inv, b)
+}
+
+/// The underlying map of an order isomorphism is an order embedding.
+theorem order_iso_map_is_order_embedding[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B]) {
+    is_order_embedding(e.map)
+} by {
+    OrderIso[A, B].constraint(e.map, e.inv)
+    is_order_iso_pair(e.map, e.inv)
+    order_iso_pair_map_is_order_embedding(e.map, e.inv)
+}
+
+/// The inverse map of an order isomorphism is an order embedding.
+theorem order_iso_inv_is_order_embedding[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B]) {
+    is_order_embedding(e.inv)
+} by {
+    order_iso_map_is_order_embedding(e)
+    forall(x: B, y: B) {
+        order_iso_right_inverse(e, x)
+        e.map(e.inv(x)) = x
+        order_iso_right_inverse(e, y)
+        e.map(e.inv(y)) = y
+        if e.inv(x) <= e.inv(y) {
+            order_embedding_apply_le(e.map, e.inv(x), e.inv(y))
+            e.map(e.inv(x)) <= e.map(e.inv(y))
+            x <= y
+        }
+        if x <= y {
+            e.map(e.inv(x)) <= e.map(e.inv(y))
+            order_embedding_reflects_lte(e.map, e.inv(x), e.inv(y))
+            e.inv(x) <= e.inv(y)
+        }
+        e.inv(x) <= e.inv(y) = (x <= y)
+    }
+}
+
+/// The underlying map of an order isomorphism is injective.
+theorem order_iso_map_is_injective[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B]) {
+    is_injective_fn(e.map)
+} by {
+    forall(x: A, y: A) {
+        if e.map(x) = e.map(y) {
+            order_iso_left_inverse(e, x)
+            order_iso_left_inverse(e, y)
+            x = y
+        }
+    }
+}
+
+/// The underlying map of an order isomorphism is surjective.
+theorem order_iso_map_is_surjective[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B]) {
+    is_surjective_fn(e.map)
+} by {
+    forall(y: B) {
+        exists(x: A) {
+            x = e.inv(y) and e.map(x) = y
+        }
+    }
+}
+
+/// The underlying map of an order isomorphism is bijective.
+theorem order_iso_map_is_bijection[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B]) {
+    is_bijection_fn(e.map)
+} by {
+    order_iso_map_is_injective(e)
+    is_injective_fn(e.map)
+    order_iso_map_is_surjective(e)
+    is_surjective_fn(e.map)
+    is_bijection_fn(e.map)
+}
+
+/// The inverse map of an order isomorphism is injective.
+theorem order_iso_inv_is_injective[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B]) {
+    is_injective_fn(e.inv)
+} by {
+    forall(x: B, y: B) {
+        if e.inv(x) = e.inv(y) {
+            order_iso_right_inverse(e, x)
+            order_iso_right_inverse(e, y)
+            x = y
+        }
+    }
+}
+
+/// The inverse map of an order isomorphism is surjective.
+theorem order_iso_inv_is_surjective[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B]) {
+    is_surjective_fn(e.inv)
+} by {
+    forall(x: A) {
+        exists(y: B) {
+            y = e.map(x) and e.inv(y) = x
+        }
+    }
+}
+
+/// The inverse map of an order isomorphism is bijective.
+theorem order_iso_inv_is_bijection[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B]) {
+    is_bijection_fn(e.inv)
+} by {
+    order_iso_inv_is_injective(e)
+    is_injective_fn(e.inv)
+    order_iso_inv_is_surjective(e)
+    is_surjective_fn(e.inv)
+    is_bijection_fn(e.inv)
+}
+
+/// An order isomorphism preserves non-strict order.
+theorem order_iso_apply_le[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], x: A, y: A) {
+    x <= y implies e.map(x) <= e.map(y)
+} by {
+    if x <= y {
+        order_iso_map_is_order_embedding(e)
+        order_embedding_apply_le(e.map, x, y)
+        e.map(x) <= e.map(y)
+    }
+}
+
+/// An order isomorphism reflects non-strict order.
+theorem order_iso_reflects_le[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], x: A, y: A) {
+    e.map(x) <= e.map(y) implies x <= y
+} by {
+    if e.map(x) <= e.map(y) {
+        order_iso_map_is_order_embedding(e)
+        order_embedding_reflects_lte(e.map, x, y)
+        x <= y
+    }
+}
+
+/// An order isomorphism preserves and reflects non-strict order.
+theorem order_iso_le_iff_le[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], x: A, y: A) {
+    e.map(x) <= e.map(y) = (x <= y)
+} by {
+    if e.map(x) <= e.map(y) {
+        order_iso_reflects_le(e, x, y)
+        x <= y
+    }
+    if x <= y {
+        order_iso_apply_le(e, x, y)
+        e.map(x) <= e.map(y)
+    }
+    e.map(x) <= e.map(y) = (x <= y)
+}
+
+/// An inverse order isomorphism preserves non-strict order.
+theorem order_iso_inv_apply_le[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], x: B, y: B) {
+    x <= y implies e.inv(x) <= e.inv(y)
+} by {
+    if x <= y {
+        order_iso_inv_is_order_embedding(e)
+        order_embedding_apply_le(e.inv, x, y)
+        e.inv(x) <= e.inv(y)
+    }
+}
+
+/// An inverse order isomorphism reflects non-strict order.
+theorem order_iso_inv_reflects_le[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], x: B, y: B) {
+    e.inv(x) <= e.inv(y) implies x <= y
+} by {
+    if e.inv(x) <= e.inv(y) {
+        order_iso_inv_is_order_embedding(e)
+        order_embedding_reflects_lte(e.inv, x, y)
+        x <= y
+    }
+}
+
+/// An inverse order isomorphism preserves and reflects non-strict order.
+theorem order_iso_inv_le_iff_le[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], x: B, y: B) {
+    e.inv(x) <= e.inv(y) = (x <= y)
+} by {
+    if e.inv(x) <= e.inv(y) {
+        order_iso_inv_reflects_le(e, x, y)
+        x <= y
+    }
+    if x <= y {
+        order_iso_inv_apply_le(e, x, y)
+        e.inv(x) <= e.inv(y)
+    }
+    e.inv(x) <= e.inv(y) = (x <= y)
+}
+
+/// The identity map as an order isomorphism.
+let identity_order_iso[A: PartialOrder](anchor: A) -> result: OrderIso[A, A] satisfy {
+    result.map = identity_fn[A] and result.inv = identity_fn[A]
+} by {
+    identity_is_order_embedding[A]
+    is_order_embedding(identity_fn[A])
+    forall(a: A) {
+        identity_fn[A](identity_fn[A](a)) = a
+    }
+    is_order_iso_pair(identity_fn[A], identity_fn[A])
+    let e: OrderIso[A, A] satisfy {
+        OrderIso[A, A].new(identity_fn[A], identity_fn[A]) = Option.some(e)
+    }
+    order_iso_new_map(identity_fn[A], identity_fn[A], e)
+    e.map = identity_fn[A]
+    order_iso_new_inv(identity_fn[A], identity_fn[A], e)
+    e.inv = identity_fn[A]
+}
+
+/// The identity order isomorphism has the identity map.
+theorem identity_order_iso_map[A: PartialOrder](anchor: A) {
+    identity_order_iso(anchor).map = identity_fn[A]
+}
+
+/// The identity order isomorphism has the identity inverse map.
+theorem identity_order_iso_inv[A: PartialOrder](anchor: A) {
+    identity_order_iso(anchor).inv = identity_fn[A]
+}


### PR DESCRIPTION
## Summary
- add `src/order_iso.ac` with order-isomorphism pairs and bundled `OrderIso` structures
- prove projection, extensionality, inverse-law, embedding, bijection, order-reflection, and identity-isomorphism lemmas
- update the translate-mathlib order-isomorphism roadmap

## Verification
- `acorn check`
