### PR TITLE
feat: add order iso bound transport

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -63,7 +63,7 @@
     "order": "8124191ac3a77667bee6ce1c91a68f5fb9a2d04a675c9590cf2b9cd1efa7f654",
     "order_cases": "adde238373d3d66729a630b83cdf897c3c22d375a2ed39a1938cea7e71eac708",
     "order_interval": "5018700234715af7c7adc712aaa6840858bc2b7cb3de98e2edb7dd75db8abf7c",
-    "order_iso": "074608539dddf29329339669ff53d06f1d64302d602bd887e40dec45ebce7327",
+    "order_iso": "2f7c3065463c1d81ffd8345de60030a62a5b18b2fb96783cc6c68514f679d914",
     "order_maps": "eaa7a667fe654a602e3fe38f85e9545e86a5d5cfe3d61fac0e61896a9db728e8",
     "order_relation": "713f57c57e155eeddf912e75a49a74f1b2c85fe76bc6884cecfdd43e71b5afb7",
     "ordered_field": "4fadab1e14de9a5e62bc1add144823af2ab3f9e2d9f380bdbab767d7cc372ae1",

--- a/build/order_iso.jsonl
+++ b/build/order_iso.jsonl
@@ -158,6 +158,126 @@
 {"goal":"e.inv(x) > e.inv(y)","proof":[]}
 {"goal":"e.inv(x) > e.inv(y) = x > y","proof":[]}
 {"goal":"order_iso_inv_gt_iff_gt","proof":[]}
+{"goal":"e.inv(e.map(x)) = x","proof":[]}
+{"goal":"order_iso_image_predicate[A, B](e, p, e.map(x)) = p(e.inv(e.map(x)))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T0 -> Bool, x2: T1) { order_iso_image_predicate[T0, T1](x0, x1, x2) = x1(x0.inv(x2)) }[A, B](e, p, e.map(x))"]}
+{"goal":"order_iso_image_predicate[A, B](e, p, e.map(x)) = p(x)","proof":[]}
+{"goal":"order_iso_image_predicate_map","proof":[]}
+{"goal":"e.map(e.inv(y)) = y","proof":[]}
+{"goal":"order_iso_preimage_predicate[A, B](e, q, e.inv(y)) = q(e.map(e.inv(y)))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T1 -> Bool, x2: T0) { order_iso_preimage_predicate[T0, T1](x0, x1, x2) = x1(x0.map(x2)) }[A, B](e, q, e.inv(y))"]}
+{"goal":"order_iso_preimage_predicate[A, B](e, q, e.inv(y)) = q(y)","proof":[]}
+{"goal":"order_iso_preimage_predicate_inv","proof":[]}
+{"goal":"p(e.inv(y))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T0 -> Bool, x2: T1) { order_iso_image_predicate[T0, T1](x0, x1, x2) = x1(x0.inv(x2)) }[A, B](e, p, y)"]}
+{"goal":"a <= e.inv(y)","proof":[]}
+{"goal":"e.map(a) <= e.map(e.inv(y))","proof":[]}
+{"goal":"e.map(e.inv(y)) = y","proof":[]}
+{"goal":"e.map(a) <= y","proof":[]}
+{"goal":"order_iso_image_lower_bound","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0) { forall(x2: T0) { not x0(x2) or x1 <= x2 } = is_lower_bound[T0](x0, x1) }[B](order_iso_image_predicate[A, B](e, p), e.map(a))"]}
+{"goal":"p(e.inv(y))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T0 -> Bool, x2: T1) { order_iso_image_predicate[T0, T1](x0, x1, x2) = x1(x0.inv(x2)) }[A, B](e, p, y)"]}
+{"goal":"e.inv(y) <= b","proof":[]}
+{"goal":"e.map(e.inv(y)) <= e.map(b)","proof":[]}
+{"goal":"e.map(e.inv(y)) = y","proof":[]}
+{"goal":"y <= e.map(b)","proof":[]}
+{"goal":"order_iso_image_upper_bound","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0) { forall(x2: T0) { not x0(x2) or x2 <= x1 } = is_upper_bound[T0](x0, x1) }[B](order_iso_image_predicate[A, B](e, p), e.map(b))"]}
+{"goal":"order_iso_image_predicate[A, B](e, p, e.map(x))","proof":[]}
+{"goal":"e.map(a) <= e.map(x)","proof":[]}
+{"goal":"a <= x","proof":[]}
+{"goal":"order_iso_reflects_image_lower_bound","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0) { forall(x2: T0) { not x0(x2) or x1 <= x2 } = is_lower_bound[T0](x0, x1) }[A](p, a)"]}
+{"goal":"order_iso_image_predicate[A, B](e, p, e.map(x))","proof":[]}
+{"goal":"e.map(x) <= e.map(b)","proof":[]}
+{"goal":"x <= b","proof":[]}
+{"goal":"order_iso_reflects_image_upper_bound","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0) { forall(x2: T0) { not x0(x2) or x2 <= x1 } = is_upper_bound[T0](x0, x1) }[A](p, b)"]}
+{"goal":"is_lower_bound(p, a)","proof":[]}
+{"goal":"is_lower_bound(order_iso_image_predicate[A, B](e, p), e.map(a))","proof":[]}
+{"goal":"is_lower_bound(order_iso_image_predicate[A, B](e, p), e.map(a)) = is_lower_bound(p, a)","proof":[]}
+{"goal":"order_iso_image_lower_bound_iff","proof":[]}
+{"goal":"is_upper_bound(p, b)","proof":[]}
+{"goal":"is_upper_bound(order_iso_image_predicate[A, B](e, p), e.map(b))","proof":[]}
+{"goal":"is_upper_bound(order_iso_image_predicate[A, B](e, p), e.map(b)) = is_upper_bound(p, b)","proof":[]}
+{"goal":"order_iso_image_upper_bound_iff","proof":[]}
+{"goal":"is_lower_bound(p, a)","proof":[]}
+{"goal":"is_lower_bound(order_iso_image_predicate[A, B](e, p), e.map(a))","proof":[]}
+{"goal":"is_upper_bound(p, b)","proof":[]}
+{"goal":"is_upper_bound(order_iso_image_predicate[A, B](e, p), e.map(b))","proof":[]}
+{"goal":"is_bounded_by_interval(order_iso_image_predicate[A, B](e, p), e.map(a), e.map(b))","proof":[]}
+{"goal":"order_iso_image_bounded_by_interval","proof":[]}
+{"goal":"is_lower_bound(order_iso_image_predicate[A, B](e, p), e.map(a))","proof":[]}
+{"goal":"is_lower_bound(p, a)","proof":[]}
+{"goal":"is_upper_bound(order_iso_image_predicate[A, B](e, p), e.map(b))","proof":[]}
+{"goal":"is_upper_bound(p, b)","proof":[]}
+{"goal":"is_bounded_by_interval(p, a, b)","proof":[]}
+{"goal":"order_iso_reflects_image_bounded_by_interval","proof":[]}
+{"goal":"is_bounded_by_interval(p, a, b)","proof":[]}
+{"goal":"is_bounded_by_interval(order_iso_image_predicate[A, B](e, p), e.map(a), e.map(b))","proof":[]}
+{"goal":"is_bounded_by_interval(order_iso_image_predicate[A, B](e, p), e.map(a), e.map(b)) = is_bounded_by_interval(p, a, b)","proof":[]}
+{"goal":"order_iso_image_bounded_by_interval_iff","proof":[]}
+{"goal":"exists(k0: A) { is_lower_bound(p, k0) }","proof":["function[T0: LinearOrder](x0: T0 -> Bool) { exists(k0: T0) { is_lower_bound[T0](x0, k0) } = is_bounded_below[T0](x0) }[A](p)"]}
+{"goal":"is_lower_bound(order_iso_image_predicate[A, B](e, p), e.map(a))","proof":[]}
+{"goal":"is_bounded_below[B](order_iso_image_predicate[A, B](e, p))","proof":[]}
+{"goal":"order_iso_image_bounded_below","proof":[]}
+{"goal":"exists(k0: A) { is_upper_bound(p, k0) }","proof":["function[T0: LinearOrder](x0: T0 -> Bool) { exists(k0: T0) { is_upper_bound[T0](x0, k0) } = is_bounded_above[T0](x0) }[A](p)"]}
+{"goal":"is_upper_bound(order_iso_image_predicate[A, B](e, p), e.map(b))","proof":[]}
+{"goal":"is_bounded_above[B](order_iso_image_predicate[A, B](e, p))","proof":[]}
+{"goal":"order_iso_image_bounded_above","proof":[]}
+{"goal":"exists(k0: A, k1: A) { is_bounded_by_interval(p, k0, k1) }","proof":["function[T0: LinearOrder](x0: T0 -> Bool) { exists(k0: T0, k1: T0) { is_bounded_by_interval[T0](x0, k0, k1) } = is_bounded[T0](x0) }[A](p)"]}
+{"goal":"is_bounded_by_interval(order_iso_image_predicate[A, B](e, p), e.map(a), e.map(b))","proof":[]}
+{"goal":"is_bounded[B](order_iso_image_predicate[A, B](e, p))","proof":[]}
+{"goal":"order_iso_image_bounded","proof":[]}
+{"goal":"q(e.map(x))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T1 -> Bool, x2: T0) { order_iso_preimage_predicate[T0, T1](x0, x1, x2) = x1(x0.map(x2)) }[A, B](e, q, x)"]}
+{"goal":"a <= e.map(x)","proof":["not q(e.map(x)) or not is_lower_bound(q, a)","not q(e.map(x))"]}
+{"goal":"e.inv(a) <= e.inv(e.map(x))","proof":["not a <= e.map(x)"]}
+{"goal":"e.inv(e.map(x)) = x","proof":[]}
+{"goal":"e.inv(a) <= x","proof":["not e.inv(a) <= e.inv(e.map(x))"]}
+{"goal":"order_iso_preimage_lower_bound","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0) { forall(x2: T0) { not x0(x2) or x1 <= x2 } = is_lower_bound[T0](x0, x1) }[A](order_iso_preimage_predicate[A, B](e, q), e.inv(a))","(forall(x0: A) { not order_iso_preimage_predicate[A, B](e, q, x0) or e.inv(a) <= x0 } = true)"]}
+{"goal":"q(e.map(x))","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: OrderIso[T0, T1], x1: T1 -> Bool, x2: T0) { order_iso_preimage_predicate[T0, T1](x0, x1, x2) = x1(x0.map(x2)) }[A, B](e, q, x)"]}
+{"goal":"e.map(x) <= b","proof":["not q(e.map(x)) or not is_upper_bound(q, b)","not q(e.map(x))"]}
+{"goal":"e.inv(e.map(x)) <= e.inv(b)","proof":["not e.map(x) <= b"]}
+{"goal":"e.inv(e.map(x)) = x","proof":[]}
+{"goal":"x <= e.inv(b)","proof":["not e.inv(e.map(x)) <= e.inv(b)"]}
+{"goal":"order_iso_preimage_upper_bound","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0) { forall(x2: T0) { not x0(x2) or x2 <= x1 } = is_upper_bound[T0](x0, x1) }[A](order_iso_preimage_predicate[A, B](e, q), e.inv(b))","(forall(x0: A) { not order_iso_preimage_predicate[A, B](e, q, x0) or x0 <= e.inv(b) } = true)"]}
+{"goal":"order_iso_preimage_predicate[A, B](e, q, e.inv(y))","proof":[]}
+{"goal":"e.inv(a) <= e.inv(y)","proof":["not is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a)) or not order_iso_preimage_predicate[A, B](e, q, e.inv(y))","not is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))"]}
+{"goal":"a <= y","proof":["not e.inv(a) <= e.inv(y)"]}
+{"goal":"order_iso_reflects_preimage_lower_bound","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0) { forall(x2: T0) { not x0(x2) or x1 <= x2 } = is_lower_bound[T0](x0, x1) }[B](q, a)","(forall(x0: B) { not q(x0) or a <= x0 } = true)"]}
+{"goal":"order_iso_preimage_predicate[A, B](e, q, e.inv(y))","proof":[]}
+{"goal":"e.inv(y) <= e.inv(b)","proof":["not is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b)) or not order_iso_preimage_predicate[A, B](e, q, e.inv(y))","not is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))"]}
+{"goal":"y <= b","proof":["not e.inv(y) <= e.inv(b)"]}
+{"goal":"order_iso_reflects_preimage_upper_bound","proof":["function[T0: LinearOrder](x0: T0 -> Bool, x1: T0) { forall(x2: T0) { not x0(x2) or x2 <= x1 } = is_upper_bound[T0](x0, x1) }[B](q, b)","(forall(x0: B) { not q(x0) or x0 <= b } = true)"]}
+{"goal":"is_lower_bound(q, a)","proof":["not is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))"]}
+{"goal":"is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))","proof":["not is_lower_bound(q, a)"]}
+{"goal":"is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a)) = is_lower_bound(q, a)","proof":["is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a)) or is_lower_bound(q, a)","is_lower_bound(q, a)","is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))","not is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))"]}
+{"goal":"order_iso_preimage_lower_bound_iff","proof":[]}
+{"goal":"is_upper_bound(q, b)","proof":["not is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))"]}
+{"goal":"is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))","proof":["not is_upper_bound(q, b)"]}
+{"goal":"is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b)) = is_upper_bound(q, b)","proof":["is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b)) or is_upper_bound(q, b)","is_upper_bound(q, b)","is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))","not is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))"]}
+{"goal":"order_iso_preimage_upper_bound_iff","proof":[]}
+{"goal":"is_lower_bound(q, a)","proof":["not is_bounded_by_interval(q, a, b)"]}
+{"goal":"is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))","proof":["not is_lower_bound(q, a)"]}
+{"goal":"is_upper_bound(q, b)","proof":["not is_bounded_by_interval(q, a, b)"]}
+{"goal":"is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))","proof":["not is_upper_bound(q, b)"]}
+{"goal":"is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b))","proof":["not is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b)) or not is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))","is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))","not is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))"]}
+{"goal":"order_iso_preimage_bounded_by_interval","proof":["not is_bounded_by_interval(q, a, b)"]}
+{"goal":"is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))","proof":["not is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b))"]}
+{"goal":"is_lower_bound(q, a)","proof":["not is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))"]}
+{"goal":"is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))","proof":["not is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b))"]}
+{"goal":"is_upper_bound(q, b)","proof":["not is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))"]}
+{"goal":"is_bounded_by_interval(q, a, b)","proof":["not is_upper_bound(q, b) or not is_lower_bound(q, a)","not is_lower_bound(q, a)"]}
+{"goal":"order_iso_reflects_preimage_bounded_by_interval","proof":["not is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b))"]}
+{"goal":"is_bounded_by_interval(q, a, b)","proof":["not is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b))"]}
+{"goal":"is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b))","proof":["not is_bounded_by_interval(q, a, b)"]}
+{"goal":"is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b)) = is_bounded_by_interval(q, a, b)","proof":["is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b)) or is_bounded_by_interval(q, a, b)","is_bounded_by_interval(q, a, b)","is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b))","not is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b))"]}
+{"goal":"order_iso_preimage_bounded_by_interval_iff","proof":[]}
+{"goal":"exists(k0: B) { is_lower_bound(q, k0) }","proof":["function[T0: LinearOrder](x0: T0 -> Bool) { exists(k0: T0) { is_lower_bound[T0](x0, k0) } = is_bounded_below[T0](x0) }[B](q)"]}
+{"goal":"is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))","proof":["not is_lower_bound(q, a)"]}
+{"goal":"is_bounded_below[A](order_iso_preimage_predicate[A, B](e, q))","proof":["not is_lower_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(a))"]}
+{"goal":"order_iso_preimage_bounded_below","proof":["not is_bounded_below[B](q)"]}
+{"goal":"exists(k0: B) { is_upper_bound(q, k0) }","proof":["function[T0: LinearOrder](x0: T0 -> Bool) { exists(k0: T0) { is_upper_bound[T0](x0, k0) } = is_bounded_above[T0](x0) }[B](q)"]}
+{"goal":"is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))","proof":["not is_upper_bound(q, b)"]}
+{"goal":"is_bounded_above[A](order_iso_preimage_predicate[A, B](e, q))","proof":["not is_upper_bound(order_iso_preimage_predicate[A, B](e, q), e.inv(b))"]}
+{"goal":"order_iso_preimage_bounded_above","proof":["not is_bounded_above[B](q)"]}
+{"goal":"exists(k0: B, k1: B) { is_bounded_by_interval(q, k0, k1) }","proof":["function[T0: LinearOrder](x0: T0 -> Bool) { exists(k0: T0, k1: T0) { is_bounded_by_interval[T0](x0, k0, k1) } = is_bounded[T0](x0) }[B](q)"]}
+{"goal":"is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b))","proof":["not is_bounded_by_interval(q, a, b)"]}
+{"goal":"is_bounded[A](order_iso_preimage_predicate[A, B](e, q))","proof":["not is_bounded_by_interval(order_iso_preimage_predicate[A, B](e, q), e.inv(a), e.inv(b))"]}
+{"goal":"order_iso_preimage_bounded","proof":["not is_bounded[B](q)"]}
 {"goal":"is_order_embedding[A, A](identity_fn[A])","proof":[]}
 {"goal":"identity_fn(identity_fn(a)) = a","proof":["function[T0](x0: T0) { identity_fn[T0](x0) = x0 }[A](a)"]}
 {"goal":"is_order_iso_pair[A, A](identity_fn[A], identity_fn[A])","proof":["function[T0: PartialOrder, T1: PartialOrder](x0: T1 -> T0, x1: T0 -> T1) { (forall(x2: T0) { x0(x1(x2)) = x2 } and forall(x3: T1) { x1(x0(x3)) = x3 } and is_order_embedding[T0, T1](x1)) = is_order_iso_pair[T0, T1](x1, x0) }[A, A](identity_fn[A], identity_fn[A])","function[T0: PartialOrder] { is_order_embedding[T0, T0](identity_fn[T0]) }[A]","not (forall(x0: A) { identity_fn(identity_fn(x0)) = x0 } and forall(x1: A) { identity_fn(identity_fn(x1)) = x1 } and is_order_embedding[A, A](identity_fn[A]))","not (forall(x2: A) { identity_fn(identity_fn(x2)) = x2 } and forall(x3: A) { identity_fn(identity_fn(x3)) = x3 })","let w0: A satisfy { identity_fn(identity_fn(w0)) != w0 }","function(x0: A) { identity_fn(identity_fn(x0)) = x0 }(w0)"]}

--- a/projects/translate-mathlib/order-theory/order-isomorphisms/todo.md
+++ b/projects/translate-mathlib/order-theory/order-isomorphisms/todo.md
@@ -6,9 +6,9 @@ Status:
 
 - `src/order_iso.ac` now defines order-isomorphism pairs and bundled `OrderIso` values, with projection, extensionality, inverse-law, embedding, bijection, order-reflection, and identity-isomorphism lemmas.
 - `src/order_iso.ac` now has inverse and composition order isomorphisms, strict and reverse-order projection lemmas, interval membership transport, and binary `min`/`max` transport.
+- `src/order_iso.ac` now has image and preimage predicate wrappers plus lower-bound, upper-bound, interval-bound, bounded-below, bounded-above, and boundedness transport lemmas for order isomorphisms.
 
 - [ ] Add coercions or wrappers for using order isomorphisms as functions
-- [ ] Add transport lemmas for order-theoretic bounds under order isomorphisms
 - [ ] Add bundled lattice-structure transport across order isomorphisms
 - [ ] Connect order isomorphisms with algebraic equivalences in ordered algebra
 - [ ] Add order duality as a standard isomorphism pattern

--- a/src/order_iso.ac
+++ b/src/order_iso.ac
@@ -2,7 +2,12 @@
 
 from functions import compose, identity_fn, is_injective_fn, is_surjective_fn, is_bijection_fn
 from order import PartialOrder, LinearOrder
-from order_interval import closed_interval, open_interval, left_open_interval, right_open_interval
+from order_interval import closed_interval, open_interval, left_open_interval, right_open_interval,
+    is_lower_bound, is_upper_bound, is_bounded_below, is_bounded_above, is_bounded_by_interval,
+    is_bounded, lower_bound_step, upper_bound_step, bounds_imp_bounded_by_interval,
+    bounded_by_interval_imp_lower_bound, bounded_by_interval_imp_upper_bound,
+    lower_bound_imp_bounded_below, upper_bound_imp_bounded_above,
+    bounded_by_interval_imp_bounded
 from order_maps import is_order_embedding, order_embedding_apply_le,
     order_embedding_apply_lt, order_embedding_apply_ge, order_embedding_apply_gt,
     order_embedding_reflects_lte, order_embedding_reflects_lt, order_embedding_reflects_ge,
@@ -186,6 +191,16 @@ structure OrderIso[A: PartialOrder, B: PartialOrder] {
     inv: B -> A
 } constraint {
     is_order_iso_pair(map, inv)
+}
+
+/// The image predicate transported by an order isomorphism.
+define order_iso_image_predicate[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], p: A -> Bool, y: B) -> Bool {
+    p(e.inv(y))
+}
+
+/// The preimage predicate transported by an order isomorphism.
+define order_iso_preimage_predicate[A: PartialOrder, B: PartialOrder](e: OrderIso[A, B], q: B -> Bool, x: A) -> Bool {
+    q(e.map(x))
 }
 
 /// Construction of an order isomorphism remembers the underlying map.
@@ -645,6 +660,542 @@ theorem order_iso_inv_gt_iff_gt[A: PartialOrder, B: PartialOrder](e: OrderIso[A,
         e.inv(x) > e.inv(y)
     }
     e.inv(x) > e.inv(y) = (x > y)
+}
+
+/// The image predicate holds at the image of exactly the original points.
+theorem order_iso_image_predicate_map[A: PartialOrder, B: PartialOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool,
+    x: A
+) {
+    order_iso_image_predicate(e, p, e.map(x)) = p(x)
+} by {
+    order_iso_left_inverse(e, x)
+    e.inv(e.map(x)) = x
+    order_iso_image_predicate(e, p, e.map(x)) = p(e.inv(e.map(x)))
+    order_iso_image_predicate(e, p, e.map(x)) = p(x)
+}
+
+/// The preimage predicate holds at the inverse image of exactly the original points.
+theorem order_iso_preimage_predicate_inv[A: PartialOrder, B: PartialOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool,
+    y: B
+) {
+    order_iso_preimage_predicate(e, q, e.inv(y)) = q(y)
+} by {
+    order_iso_right_inverse(e, y)
+    e.map(e.inv(y)) = y
+    order_iso_preimage_predicate(e, q, e.inv(y)) = q(e.map(e.inv(y)))
+    order_iso_preimage_predicate(e, q, e.inv(y)) = q(y)
+}
+
+/// An order isomorphism carries a lower bound to a lower bound of the image predicate.
+theorem order_iso_image_lower_bound[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool,
+    a: A
+) {
+    is_lower_bound(p, a) implies is_lower_bound(order_iso_image_predicate(e, p), e.map(a))
+} by {
+    if is_lower_bound(p, a) {
+        forall(y: B) {
+            if order_iso_image_predicate(e, p, y) {
+                p(e.inv(y))
+                lower_bound_step(p, a, e.inv(y))
+                a <= e.inv(y)
+                order_iso_apply_le(e, a, e.inv(y))
+                e.map(a) <= e.map(e.inv(y))
+                order_iso_right_inverse(e, y)
+                e.map(e.inv(y)) = y
+                e.map(a) <= y
+            }
+        }
+    }
+}
+
+/// An order isomorphism carries an upper bound to an upper bound of the image predicate.
+theorem order_iso_image_upper_bound[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool,
+    b: A
+) {
+    is_upper_bound(p, b) implies is_upper_bound(order_iso_image_predicate(e, p), e.map(b))
+} by {
+    if is_upper_bound(p, b) {
+        forall(y: B) {
+            if order_iso_image_predicate(e, p, y) {
+                p(e.inv(y))
+                upper_bound_step(p, b, e.inv(y))
+                e.inv(y) <= b
+                order_iso_apply_le(e, e.inv(y), b)
+                e.map(e.inv(y)) <= e.map(b)
+                order_iso_right_inverse(e, y)
+                e.map(e.inv(y)) = y
+                y <= e.map(b)
+            }
+        }
+    }
+}
+
+/// A lower bound of the image predicate reflects to a lower bound of the original predicate.
+theorem order_iso_reflects_image_lower_bound[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool,
+    a: A
+) {
+    is_lower_bound(order_iso_image_predicate(e, p), e.map(a)) implies is_lower_bound(p, a)
+} by {
+    if is_lower_bound(order_iso_image_predicate(e, p), e.map(a)) {
+        forall(x: A) {
+            if p(x) {
+                order_iso_image_predicate_map(e, p, x)
+                order_iso_image_predicate(e, p, e.map(x))
+                lower_bound_step(order_iso_image_predicate(e, p), e.map(a), e.map(x))
+                e.map(a) <= e.map(x)
+                order_iso_reflects_le(e, a, x)
+                a <= x
+            }
+        }
+    }
+}
+
+/// An upper bound of the image predicate reflects to an upper bound of the original predicate.
+theorem order_iso_reflects_image_upper_bound[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool,
+    b: A
+) {
+    is_upper_bound(order_iso_image_predicate(e, p), e.map(b)) implies is_upper_bound(p, b)
+} by {
+    if is_upper_bound(order_iso_image_predicate(e, p), e.map(b)) {
+        forall(x: A) {
+            if p(x) {
+                order_iso_image_predicate_map(e, p, x)
+                order_iso_image_predicate(e, p, e.map(x))
+                upper_bound_step(order_iso_image_predicate(e, p), e.map(b), e.map(x))
+                e.map(x) <= e.map(b)
+                order_iso_reflects_le(e, x, b)
+                x <= b
+            }
+        }
+    }
+}
+
+/// Lower bounds are preserved and reflected by image predicates under an order isomorphism.
+theorem order_iso_image_lower_bound_iff[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool,
+    a: A
+) {
+    is_lower_bound(order_iso_image_predicate(e, p), e.map(a)) = is_lower_bound(p, a)
+} by {
+    if is_lower_bound(order_iso_image_predicate(e, p), e.map(a)) {
+        order_iso_reflects_image_lower_bound(e, p, a)
+        is_lower_bound(p, a)
+    }
+    if is_lower_bound(p, a) {
+        order_iso_image_lower_bound(e, p, a)
+        is_lower_bound(order_iso_image_predicate(e, p), e.map(a))
+    }
+    is_lower_bound(order_iso_image_predicate(e, p), e.map(a)) = is_lower_bound(p, a)
+}
+
+/// Upper bounds are preserved and reflected by image predicates under an order isomorphism.
+theorem order_iso_image_upper_bound_iff[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool,
+    b: A
+) {
+    is_upper_bound(order_iso_image_predicate(e, p), e.map(b)) = is_upper_bound(p, b)
+} by {
+    if is_upper_bound(order_iso_image_predicate(e, p), e.map(b)) {
+        order_iso_reflects_image_upper_bound(e, p, b)
+        is_upper_bound(p, b)
+    }
+    if is_upper_bound(p, b) {
+        order_iso_image_upper_bound(e, p, b)
+        is_upper_bound(order_iso_image_predicate(e, p), e.map(b))
+    }
+    is_upper_bound(order_iso_image_predicate(e, p), e.map(b)) = is_upper_bound(p, b)
+}
+
+/// An order isomorphism carries an interval bound to an interval bound of the image predicate.
+theorem order_iso_image_bounded_by_interval[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool,
+    a: A,
+    b: A
+) {
+    is_bounded_by_interval(p, a, b) implies
+    is_bounded_by_interval(order_iso_image_predicate(e, p), e.map(a), e.map(b))
+} by {
+    if is_bounded_by_interval(p, a, b) {
+        bounded_by_interval_imp_lower_bound(p, a, b)
+        is_lower_bound(p, a)
+        order_iso_image_lower_bound(e, p, a)
+        is_lower_bound(order_iso_image_predicate(e, p), e.map(a))
+        bounded_by_interval_imp_upper_bound(p, a, b)
+        is_upper_bound(p, b)
+        order_iso_image_upper_bound(e, p, b)
+        is_upper_bound(order_iso_image_predicate(e, p), e.map(b))
+        bounds_imp_bounded_by_interval(order_iso_image_predicate(e, p), e.map(a), e.map(b))
+        is_bounded_by_interval(order_iso_image_predicate(e, p), e.map(a), e.map(b))
+    }
+}
+
+/// Interval bounds of image predicates reflect through an order isomorphism.
+theorem order_iso_reflects_image_bounded_by_interval[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool,
+    a: A,
+    b: A
+) {
+    is_bounded_by_interval(order_iso_image_predicate(e, p), e.map(a), e.map(b)) implies
+    is_bounded_by_interval(p, a, b)
+} by {
+    if is_bounded_by_interval(order_iso_image_predicate(e, p), e.map(a), e.map(b)) {
+        bounded_by_interval_imp_lower_bound(order_iso_image_predicate(e, p), e.map(a), e.map(b))
+        is_lower_bound(order_iso_image_predicate(e, p), e.map(a))
+        order_iso_reflects_image_lower_bound(e, p, a)
+        is_lower_bound(p, a)
+        bounded_by_interval_imp_upper_bound(order_iso_image_predicate(e, p), e.map(a), e.map(b))
+        is_upper_bound(order_iso_image_predicate(e, p), e.map(b))
+        order_iso_reflects_image_upper_bound(e, p, b)
+        is_upper_bound(p, b)
+        bounds_imp_bounded_by_interval(p, a, b)
+        is_bounded_by_interval(p, a, b)
+    }
+}
+
+/// Interval bounds are preserved and reflected by image predicates under an order isomorphism.
+theorem order_iso_image_bounded_by_interval_iff[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool,
+    a: A,
+    b: A
+) {
+    is_bounded_by_interval(order_iso_image_predicate(e, p), e.map(a), e.map(b)) =
+    is_bounded_by_interval(p, a, b)
+} by {
+    if is_bounded_by_interval(order_iso_image_predicate(e, p), e.map(a), e.map(b)) {
+        order_iso_reflects_image_bounded_by_interval(e, p, a, b)
+        is_bounded_by_interval(p, a, b)
+    }
+    if is_bounded_by_interval(p, a, b) {
+        order_iso_image_bounded_by_interval(e, p, a, b)
+        is_bounded_by_interval(order_iso_image_predicate(e, p), e.map(a), e.map(b))
+    }
+    is_bounded_by_interval(order_iso_image_predicate(e, p), e.map(a), e.map(b)) =
+    is_bounded_by_interval(p, a, b)
+}
+
+/// Boundedness below is preserved by image predicates under an order isomorphism.
+theorem order_iso_image_bounded_below[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool
+) {
+    is_bounded_below(p) implies is_bounded_below(order_iso_image_predicate(e, p))
+} by {
+    if is_bounded_below(p) {
+        let a: A satisfy {
+            is_lower_bound(p, a)
+        }
+        order_iso_image_lower_bound(e, p, a)
+        is_lower_bound(order_iso_image_predicate(e, p), e.map(a))
+        lower_bound_imp_bounded_below(order_iso_image_predicate(e, p), e.map(a))
+        is_bounded_below(order_iso_image_predicate(e, p))
+    }
+}
+
+/// Boundedness above is preserved by image predicates under an order isomorphism.
+theorem order_iso_image_bounded_above[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool
+) {
+    is_bounded_above(p) implies is_bounded_above(order_iso_image_predicate(e, p))
+} by {
+    if is_bounded_above(p) {
+        let b: A satisfy {
+            is_upper_bound(p, b)
+        }
+        order_iso_image_upper_bound(e, p, b)
+        is_upper_bound(order_iso_image_predicate(e, p), e.map(b))
+        upper_bound_imp_bounded_above(order_iso_image_predicate(e, p), e.map(b))
+        is_bounded_above(order_iso_image_predicate(e, p))
+    }
+}
+
+/// Boundedness is preserved by image predicates under an order isomorphism.
+theorem order_iso_image_bounded[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    p: A -> Bool
+) {
+    is_bounded(p) implies is_bounded(order_iso_image_predicate(e, p))
+} by {
+    if is_bounded(p) {
+        let (a: A, b: A) satisfy {
+            is_bounded_by_interval(p, a, b)
+        }
+        order_iso_image_bounded_by_interval(e, p, a, b)
+        is_bounded_by_interval(order_iso_image_predicate(e, p), e.map(a), e.map(b))
+        bounded_by_interval_imp_bounded(order_iso_image_predicate(e, p), e.map(a), e.map(b))
+        is_bounded(order_iso_image_predicate(e, p))
+    }
+}
+
+/// An order isomorphism carries a lower bound backward to a lower bound of the preimage predicate.
+theorem order_iso_preimage_lower_bound[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool,
+    a: B
+) {
+    is_lower_bound(q, a) implies is_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a))
+} by {
+    if is_lower_bound(q, a) {
+        forall(x: A) {
+            if order_iso_preimage_predicate(e, q, x) {
+                q(e.map(x))
+                lower_bound_step(q, a, e.map(x))
+                a <= e.map(x)
+                order_iso_inv_apply_le(e, a, e.map(x))
+                e.inv(a) <= e.inv(e.map(x))
+                order_iso_left_inverse(e, x)
+                e.inv(e.map(x)) = x
+                e.inv(a) <= x
+            }
+        }
+    }
+}
+
+/// An order isomorphism carries an upper bound backward to an upper bound of the preimage predicate.
+theorem order_iso_preimage_upper_bound[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool,
+    b: B
+) {
+    is_upper_bound(q, b) implies is_upper_bound(order_iso_preimage_predicate(e, q), e.inv(b))
+} by {
+    if is_upper_bound(q, b) {
+        forall(x: A) {
+            if order_iso_preimage_predicate(e, q, x) {
+                q(e.map(x))
+                upper_bound_step(q, b, e.map(x))
+                e.map(x) <= b
+                order_iso_inv_apply_le(e, e.map(x), b)
+                e.inv(e.map(x)) <= e.inv(b)
+                order_iso_left_inverse(e, x)
+                e.inv(e.map(x)) = x
+                x <= e.inv(b)
+            }
+        }
+    }
+}
+
+/// A lower bound of the preimage predicate reflects to a lower bound of the original predicate.
+theorem order_iso_reflects_preimage_lower_bound[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool,
+    a: B
+) {
+    is_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a)) implies is_lower_bound(q, a)
+} by {
+    if is_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a)) {
+        forall(y: B) {
+            if q(y) {
+                order_iso_preimage_predicate_inv(e, q, y)
+                order_iso_preimage_predicate(e, q, e.inv(y))
+                lower_bound_step(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(y))
+                e.inv(a) <= e.inv(y)
+                order_iso_inv_reflects_le(e, a, y)
+                a <= y
+            }
+        }
+    }
+}
+
+/// An upper bound of the preimage predicate reflects to an upper bound of the original predicate.
+theorem order_iso_reflects_preimage_upper_bound[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool,
+    b: B
+) {
+    is_upper_bound(order_iso_preimage_predicate(e, q), e.inv(b)) implies is_upper_bound(q, b)
+} by {
+    if is_upper_bound(order_iso_preimage_predicate(e, q), e.inv(b)) {
+        forall(y: B) {
+            if q(y) {
+                order_iso_preimage_predicate_inv(e, q, y)
+                order_iso_preimage_predicate(e, q, e.inv(y))
+                upper_bound_step(order_iso_preimage_predicate(e, q), e.inv(b), e.inv(y))
+                e.inv(y) <= e.inv(b)
+                order_iso_inv_reflects_le(e, y, b)
+                y <= b
+            }
+        }
+    }
+}
+
+/// Lower bounds are preserved and reflected by preimage predicates under an order isomorphism.
+theorem order_iso_preimage_lower_bound_iff[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool,
+    a: B
+) {
+    is_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a)) = is_lower_bound(q, a)
+} by {
+    if is_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a)) {
+        order_iso_reflects_preimage_lower_bound(e, q, a)
+        is_lower_bound(q, a)
+    }
+    if is_lower_bound(q, a) {
+        order_iso_preimage_lower_bound(e, q, a)
+        is_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a))
+    }
+    is_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a)) = is_lower_bound(q, a)
+}
+
+/// Upper bounds are preserved and reflected by preimage predicates under an order isomorphism.
+theorem order_iso_preimage_upper_bound_iff[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool,
+    b: B
+) {
+    is_upper_bound(order_iso_preimage_predicate(e, q), e.inv(b)) = is_upper_bound(q, b)
+} by {
+    if is_upper_bound(order_iso_preimage_predicate(e, q), e.inv(b)) {
+        order_iso_reflects_preimage_upper_bound(e, q, b)
+        is_upper_bound(q, b)
+    }
+    if is_upper_bound(q, b) {
+        order_iso_preimage_upper_bound(e, q, b)
+        is_upper_bound(order_iso_preimage_predicate(e, q), e.inv(b))
+    }
+    is_upper_bound(order_iso_preimage_predicate(e, q), e.inv(b)) = is_upper_bound(q, b)
+}
+
+/// An order isomorphism carries an interval bound backward to an interval bound of the preimage predicate.
+theorem order_iso_preimage_bounded_by_interval[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool,
+    a: B,
+    b: B
+) {
+    is_bounded_by_interval(q, a, b) implies
+    is_bounded_by_interval(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b))
+} by {
+    if is_bounded_by_interval(q, a, b) {
+        bounded_by_interval_imp_lower_bound(q, a, b)
+        is_lower_bound(q, a)
+        order_iso_preimage_lower_bound(e, q, a)
+        is_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a))
+        bounded_by_interval_imp_upper_bound(q, a, b)
+        is_upper_bound(q, b)
+        order_iso_preimage_upper_bound(e, q, b)
+        is_upper_bound(order_iso_preimage_predicate(e, q), e.inv(b))
+        bounds_imp_bounded_by_interval(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b))
+        is_bounded_by_interval(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b))
+    }
+}
+
+/// Interval bounds of preimage predicates reflect through an order isomorphism.
+theorem order_iso_reflects_preimage_bounded_by_interval[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool,
+    a: B,
+    b: B
+) {
+    is_bounded_by_interval(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b)) implies
+    is_bounded_by_interval(q, a, b)
+} by {
+    if is_bounded_by_interval(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b)) {
+        bounded_by_interval_imp_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b))
+        is_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a))
+        order_iso_reflects_preimage_lower_bound(e, q, a)
+        is_lower_bound(q, a)
+        bounded_by_interval_imp_upper_bound(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b))
+        is_upper_bound(order_iso_preimage_predicate(e, q), e.inv(b))
+        order_iso_reflects_preimage_upper_bound(e, q, b)
+        is_upper_bound(q, b)
+        bounds_imp_bounded_by_interval(q, a, b)
+        is_bounded_by_interval(q, a, b)
+    }
+}
+
+/// Interval bounds are preserved and reflected by preimage predicates under an order isomorphism.
+theorem order_iso_preimage_bounded_by_interval_iff[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool,
+    a: B,
+    b: B
+) {
+    is_bounded_by_interval(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b)) =
+    is_bounded_by_interval(q, a, b)
+} by {
+    if is_bounded_by_interval(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b)) {
+        order_iso_reflects_preimage_bounded_by_interval(e, q, a, b)
+        is_bounded_by_interval(q, a, b)
+    }
+    if is_bounded_by_interval(q, a, b) {
+        order_iso_preimage_bounded_by_interval(e, q, a, b)
+        is_bounded_by_interval(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b))
+    }
+    is_bounded_by_interval(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b)) =
+    is_bounded_by_interval(q, a, b)
+}
+
+/// Boundedness below is preserved by preimage predicates under an order isomorphism.
+theorem order_iso_preimage_bounded_below[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool
+) {
+    is_bounded_below(q) implies is_bounded_below(order_iso_preimage_predicate(e, q))
+} by {
+    if is_bounded_below(q) {
+        let a: B satisfy {
+            is_lower_bound(q, a)
+        }
+        order_iso_preimage_lower_bound(e, q, a)
+        is_lower_bound(order_iso_preimage_predicate(e, q), e.inv(a))
+        lower_bound_imp_bounded_below(order_iso_preimage_predicate(e, q), e.inv(a))
+        is_bounded_below(order_iso_preimage_predicate(e, q))
+    }
+}
+
+/// Boundedness above is preserved by preimage predicates under an order isomorphism.
+theorem order_iso_preimage_bounded_above[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool
+) {
+    is_bounded_above(q) implies is_bounded_above(order_iso_preimage_predicate(e, q))
+} by {
+    if is_bounded_above(q) {
+        let b: B satisfy {
+            is_upper_bound(q, b)
+        }
+        order_iso_preimage_upper_bound(e, q, b)
+        is_upper_bound(order_iso_preimage_predicate(e, q), e.inv(b))
+        upper_bound_imp_bounded_above(order_iso_preimage_predicate(e, q), e.inv(b))
+        is_bounded_above(order_iso_preimage_predicate(e, q))
+    }
+}
+
+/// Boundedness is preserved by preimage predicates under an order isomorphism.
+theorem order_iso_preimage_bounded[A: LinearOrder, B: LinearOrder](
+    e: OrderIso[A, B],
+    q: B -> Bool
+) {
+    is_bounded(q) implies is_bounded(order_iso_preimage_predicate(e, q))
+} by {
+    if is_bounded(q) {
+        let (a: B, b: B) satisfy {
+            is_bounded_by_interval(q, a, b)
+        }
+        order_iso_preimage_bounded_by_interval(e, q, a, b)
+        is_bounded_by_interval(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b))
+        bounded_by_interval_imp_bounded(order_iso_preimage_predicate(e, q), e.inv(a), e.inv(b))
+        is_bounded(order_iso_preimage_predicate(e, q))
+    }
 }
 
 /// The identity map as an order isomorphism.


### PR DESCRIPTION
## Summary
- Add order-isomorphism image/preimage predicate wrappers.
- Prove lower-bound, upper-bound, interval-bound, bounded-below, bounded-above, and boundedness transport lemmas in both directions.
- Update the translate-mathlib order-isomorphisms roadmap.

## Verification
- `acorn check`

Stacked on #251 (`translate-mathlib-chunk-20260501-152718`).
