### PR TITLE
feat: add set lattice API

### DIFF
--- a/build/manifest.json
+++ b/build/manifest.json
@@ -102,6 +102,7 @@
     "semiring.from_nat": "bc48065c0aa4c8cc0688df7ae0ab8239b3683343870fc15c765b48c600896c29",
     "semiring_hom": "b7320fd02dbdd2ed4194aa3a6a31907b8cfab066f00f247bf2b0523b22506798",
     "set": "8474a3a6b24f9eb392aa82ecd7295c3ce4fb51637aef800c40c18c91e82cff4b",
+    "set_lattice": "8e453bfbf2b1116abbac454dc3783caeb60e0f95fcdbdc70d6ca3e85b6b15e3f",
     "subgroup": "e9457fa64da77fd056ccaaad313c7d218e7056b4768c6088a4941eeb1e8797aa",
     "submodule": "db00c58eb94a2782a29c03e94609bfa7d3c8f9a40fcd5d5ed50d3e1664cecf7e",
     "submonoid": "756ed81998e7f5445dad6eca9aaa70fa77c86e6a95865a79a6e9d648d39853cd",

--- a/build/set_lattice.jsonl
+++ b/build/set_lattice.jsonl
@@ -1,0 +1,101 @@
+{"goal":"set_inf_contains_eq","proof":[]}
+{"goal":"set_sup_contains_eq","proof":[]}
+{"goal":"a.intersection(b).subset(a)","proof":[]}
+{"goal":"set_inf_subset_left","proof":[]}
+{"goal":"a.intersection(b).subset(b)","proof":[]}
+{"goal":"set_inf_subset_right","proof":[]}
+{"goal":"a.superset(c)","proof":["function[T0](x0: Set[T0], x1: Set[T0]) { forall(x2: T0) { not x2 ∈ x0 or x2 ∈ x1 } = x1 ⊃ x0 }[K](c, a)","function[T0](x0: Set[T0], x1: Set[T0]) { forall(x2: T0) { not x2 ∈ x0 or x2 ∈ x1 } = x0 ⊂ x1 }[K](c, a)"]}
+{"goal":"b.superset(c)","proof":["function[T0](x0: Set[T0], x1: Set[T0]) { forall(x2: T0) { not x2 ∈ x0 or x2 ∈ x1 } = x1 ⊃ x0 }[K](c, b)","function[T0](x0: Set[T0], x1: Set[T0]) { forall(x2: T0) { not x2 ∈ x0 or x2 ∈ x1 } = x0 ⊂ x1 }[K](c, b)"]}
+{"goal":"a.intersection(b).superset(c)","proof":[]}
+{"goal":"c.subset(a.intersection(b))","proof":["function[T0](x0: Set[T0], x1: Set[T0]) { forall(x2: T0) { not x2 ∈ x0 or x2 ∈ x1 } = x1 ⊃ x0 }[K](c, a ∩ b)","function[T0](x0: Set[T0], x1: Set[T0]) { forall(x2: T0) { not x2 ∈ x0 or x2 ∈ x1 } = x0 ⊂ x1 }[K](c, a ∩ b)"]}
+{"goal":"c.subset(set_inf[K](a, b))","proof":[]}
+{"goal":"set_subset_inf_of_subset_left_right","proof":[]}
+{"goal":"c.subset(a)","proof":[]}
+{"goal":"c.subset(b)","proof":[]}
+{"goal":"c.subset(a) and c.subset(b)","proof":[]}
+{"goal":"c.subset(set_inf[K](a, b))","proof":[]}
+{"goal":"c.subset(set_inf[K](a, b)) = (c.subset(a) and c.subset(b))","proof":[]}
+{"goal":"set_subset_inf_iff","proof":[]}
+{"goal":"a.subset(a.union(b))","proof":[]}
+{"goal":"set_subset_sup_left","proof":[]}
+{"goal":"b.subset(a.union(b))","proof":[]}
+{"goal":"set_subset_sup_right","proof":[]}
+{"goal":"a.union(b).subset(c)","proof":[]}
+{"goal":"set_sup[K](a, b).subset(c)","proof":[]}
+{"goal":"set_sup_subset_of_subset_left_right","proof":[]}
+{"goal":"a.subset(c)","proof":[]}
+{"goal":"b.subset(c)","proof":[]}
+{"goal":"a.subset(c) and b.subset(c)","proof":[]}
+{"goal":"set_sup[K](a, b).subset(c)","proof":[]}
+{"goal":"set_sup[K](a, b).subset(c) = (a.subset(c) and b.subset(c))","proof":[]}
+{"goal":"set_sup_subset_iff","proof":[]}
+{"goal":"set_inf_comm","proof":[]}
+{"goal":"set_sup_comm","proof":[]}
+{"goal":"set_inf_assoc","proof":[]}
+{"goal":"set_sup_assoc","proof":[]}
+{"goal":"set_inf_idem","proof":[]}
+{"goal":"set_sup_idem","proof":[]}
+{"goal":"set_inf_universal_right","proof":[]}
+{"goal":"set_inf_universal_left","proof":[]}
+{"goal":"set_sup_empty_right","proof":[]}
+{"goal":"set_sup_empty_left","proof":[]}
+{"goal":"set_inf_empty_right","proof":[]}
+{"goal":"set_inf_empty_left","proof":[]}
+{"goal":"set_sup_universal_right","proof":[]}
+{"goal":"set_sup_universal_left","proof":[]}
+{"goal":"set_inf[K](a, set_sup[K](a, b)).subset(a)","proof":[]}
+{"goal":"a.subset(set_inf[K](a, set_sup[K](a, b)))","proof":["function[T0](x0: Set[T0], x1: Set[T0]) { x0 ⊂ set_sup[T0](x1, x0) }[K](a, Set.empty_set[K])","function[T0](x0: Set[T0]) { set_sup[T0](Set.empty_set[T0], x0) = x0 }[K](a)"]}
+{"goal":"set_inf_sup_absorb","proof":[]}
+{"goal":"a.subset(set_sup[K](a, set_inf[K](a, b)))","proof":[]}
+{"goal":"set_sup[K](a, set_inf[K](a, b)).subset(a)","proof":["function[T0](x0: Set[T0], x1: Set[T0]) { x0 ⊂ set_sup[T0](x1, x0) }[K](a, Set.empty_set[K])","function[T0](x0: Set[T0]) { set_sup[T0](Set.empty_set[T0], x0) = x0 }[K](a)"]}
+{"goal":"set_sup_inf_absorb","proof":[]}
+{"goal":"a.contains(x)","proof":[]}
+{"goal":"set_sup[K](b, c).contains(x)","proof":[]}
+{"goal":"set_inf[K](a, b).contains(x)","proof":[]}
+{"goal":"v.contains(x)","proof":[]}
+{"goal":"c.contains(x)","proof":[]}
+{"goal":"set_inf[K](a, c).contains(x)","proof":[]}
+{"goal":"v.contains(x)","proof":[]}
+{"goal":"a.contains(x)","proof":[]}
+{"goal":"b.contains(x)","proof":[]}
+{"goal":"set_sup[K](b, c).contains(x)","proof":[]}
+{"goal":"u.contains(x)","proof":[]}
+{"goal":"set_inf[K](a, c).contains(x)","proof":[]}
+{"goal":"a.contains(x)","proof":[]}
+{"goal":"c.contains(x)","proof":[]}
+{"goal":"set_sup[K](b, c).contains(x)","proof":[]}
+{"goal":"u.contains(x)","proof":[]}
+{"goal":"u.contains(x) = v.contains(x)","proof":[]}
+{"goal":"set_inf_sup_distrib_left","proof":["function[T0](x0: Set[T0]) { Set.new[T0](x0.contains) = x0 }[K](set_inf[K](a, set_sup[K](b, c)))","function[T0](x0: Set[T0]) { Set.new[T0](x0.contains) = x0 }[K](set_sup[K](set_inf[K](a, b), set_inf[K](a, c)))"]}
+{"goal":"set_sup_inf_distrib_left","proof":[]}
+{"goal":"set_sSup_contains_eq","proof":[]}
+{"goal":"set_sInf_contains_eq","proof":[]}
+{"goal":"set_sSup[K, I](family).contains(x)","proof":[]}
+{"goal":"set_family_subset_sSup","proof":["function[T0](x0: Set[T0], x1: Set[T0]) { forall(x2: T0) { not x2 ∈ x0 or x2 ∈ x1 } = x0 ⊂ x1 }[K](family(i), set_sSup[K, I](family))","let w0: K satisfy { w0 ∈ family(i) and not w0 ∈ set_sSup[K, I](family) }","function[T0, T1](x0: T0 -> Set[T1], x1: T1) { exists(k0: T0) { x1 ∈ x0(k0) } = x1 ∈ set_sSup[T1, T0](x0) }[I, K](family, w0)","function[T0, T1](x0: T0 -> Set[T1], x1: T1) { not exists(k0: T0) { x1 ∈ x0(k0) } or x1 ∈ set_sSup[T1, T0](x0) }[I, K](family, w0)","function[T0, T1](x0: T1 -> Set[T0], x1: T1, x2: T0) { not x2 ∈ x0(x1) or x2 ∈ set_sSup[T0, T1](x0) }[K, I](family, i, w0)"]}
+{"goal":"set_sSup[K, I](family).subset(s)","proof":["function[T0, T1](x0: T1 -> Set[T0]) { set_sSup[T0, T1](x0) = indexed_union[T0, T1](x0) }[K, I](family)","not indexed_union[K, I](family) ⊂ s","let w0: I satisfy { not family(w0) ⊂ s }","function(x0: I) { family(x0) ⊂ s }(w0)"]}
+{"goal":"set_sSup_subset_of_family_subset","proof":["let w0: I satisfy { not family(w0) ⊂ s }","function(x0: I) { family(x0) ⊂ s }(w0)"]}
+{"goal":"family(i).subset(s)","proof":[]}
+{"goal":"set_sSup[K, I](family).subset(s)","proof":["let w0: I satisfy { not family(w0) ⊂ s }","function(x0: I) { family(x0) ⊂ s }(w0)"]}
+{"goal":"set_sSup[K, I](family).subset(s) = forall(x0: I) { family(x0).subset(s) }","proof":[]}
+{"goal":"set_sSup_subset_iff","proof":[]}
+{"goal":"family(i).contains(x)","proof":[]}
+{"goal":"set_sInf_subset_family","proof":["function[T0](x0: Set[T0], x1: Set[T0]) { forall(x2: T0) { not x2 ∈ x0 or x2 ∈ x1 } = x0 ⊂ x1 }[K](set_sInf[K, I](family), family(i))","let w0: K satisfy { w0 ∈ set_sInf[K, I](family) and not w0 ∈ family(i) }","function[T0, T1](x0: T0 -> Set[T1], x1: T1) { forall(x2: T0) { x1 ∈ x0(x2) } = x1 ∈ set_sInf[T1, T0](x0) }[I, K](family, w0)","function[T0, T1](x0: T1 -> Set[T0], x1: T0) { not x1 ∈ set_sInf[T0, T1](x0) or forall(x2: T1) { x1 ∈ x0(x2) } = true }[K, I](family, w0)","function[T0, T1](x0: T1 -> Set[T0], x1: T0, x2: T1) { not x1 ∈ set_sInf[T0, T1](x0) or x1 ∈ x0(x2) }[K, I](family, w0, i)"]}
+{"goal":"indexed_intersection[K, I](family).superset(s)","proof":["let w0: I satisfy { not s ⊂ family(w0) }","function(x0: I) { s ⊂ family(x0) }(w0)"]}
+{"goal":"s.subset(set_sInf[K, I](family))","proof":["function[T0, T1](x0: T1 -> Set[T0]) { set_sInf[T0, T1](x0) = indexed_intersection[T0, T1](x0) }[K, I](family)","function[T0](x0: Set[T0], x1: Set[T0]) { x0 ⊃ x1 = x1 ⊂ x0 }[K](set_sInf[K, I](family), s)"]}
+{"goal":"set_subset_sInf_of_subset_family","proof":["let w0: I satisfy { not s ⊂ family(w0) }","function(x0: I) { s ⊂ family(x0) }(w0)"]}
+{"goal":"s.subset(family(i))","proof":[]}
+{"goal":"s.subset(set_sInf[K, I](family))","proof":["let w0: I satisfy { not s ⊂ family(w0) }","function(x0: I) { s ⊂ family(x0) }(w0)"]}
+{"goal":"s.subset(set_sInf[K, I](family)) = forall(x0: I) { s.subset(family(x0)) }","proof":[]}
+{"goal":"set_subset_sInf_iff","proof":[]}
+{"goal":"indexed_union[K, I](a).subset(indexed_union[K, I](b))","proof":["let w0: I satisfy { not a(w0) ⊂ b(w0) }","function(x0: I) { a(x0) ⊂ b(x0) }(w0)"]}
+{"goal":"set_sSup[K, I](a) = indexed_union[K, I](a)","proof":["function[T0, T1](x0: T1 -> Set[T0]) { set_sSup[T0, T1](x0) = indexed_union[T0, T1](x0) }[K, I](a)"]}
+{"goal":"set_sSup[K, I](b) = indexed_union[K, I](b)","proof":["function[T0, T1](x0: T1 -> Set[T0]) { set_sSup[T0, T1](x0) = indexed_union[T0, T1](x0) }[K, I](b)"]}
+{"goal":"set_sSup[K, I](a).subset(set_sSup[K, I](b))","proof":["not indexed_union[K, I](a) ⊂ set_sSup[K, I](b)","indexed_union[K, I](a) ⊂ set_sSup[K, I](b)"]}
+{"goal":"set_sSup_monotone","proof":["let w0: I satisfy { not a(w0) ⊂ b(w0) }","function(x0: I) { a(x0) ⊂ b(x0) }(w0)"]}
+{"goal":"indexed_intersection[K, I](a).subset(indexed_intersection[K, I](b))","proof":["let w0: I satisfy { not a(w0) ⊂ b(w0) }","function(x0: I) { a(x0) ⊂ b(x0) }(w0)"]}
+{"goal":"set_sInf[K, I](a) = indexed_intersection[K, I](a)","proof":["function[T0, T1](x0: T1 -> Set[T0]) { set_sInf[T0, T1](x0) = indexed_intersection[T0, T1](x0) }[K, I](a)"]}
+{"goal":"set_sInf[K, I](b) = indexed_intersection[K, I](b)","proof":["function[T0, T1](x0: T1 -> Set[T0]) { set_sInf[T0, T1](x0) = indexed_intersection[T0, T1](x0) }[K, I](b)"]}
+{"goal":"set_sInf[K, I](a).subset(set_sInf[K, I](b))","proof":["not indexed_intersection[K, I](a) ⊂ set_sInf[K, I](b)","indexed_intersection[K, I](a) ⊂ set_sInf[K, I](b)"]}
+{"goal":"set_sInf_monotone","proof":["let w0: I satisfy { not a(w0) ⊂ b(w0) }","function(x0: I) { a(x0) ⊂ b(x0) }(w0)"]}
+{"goal":"set_sSup_is_lub","proof":["let w0: I satisfy { not family(w0) ⊂ set_sSup[K, I](family) }","function(x0: I) { family(x0) ⊂ set_sSup[K, I](family) }(w0)"]}
+{"goal":"set_sInf_is_glb","proof":["let w0: I satisfy { not set_sInf[K, I](family) ⊂ family(w0) }","function(x0: I) { set_sInf[K, I](family) ⊂ family(x0) }(w0)"]}

--- a/projects/translate-mathlib/order-theory/basic-orders/todo.md
+++ b/projects/translate-mathlib/order-theory/basic-orders/todo.md
@@ -2,7 +2,6 @@
 
 Goal: stabilize the base order hierarchy so later order-theoretic and ordered-algebraic code can depend on one standard API.
 
-- [ ] Finish auditing numeric construction-local order theorem names that cannot yet be replaced by generic `LinearOrder` facts
 - [ ] Decide whether Acornlib needs a `Preorder` layer below `PartialOrder`
 
 Status:
@@ -22,3 +21,4 @@ Status:
 - The generic order API now includes literal swapped `le`/`lt` disjunction aliases and Nat-style literal trichotomy aliases in `src/order.ac` and `src/order_cases.ac`.
 - `src/order_interval.ac` now has Mathlib-style `le`/`lt` aliases for interval introduction/projection and clamp monotonicity, so downstream files can avoid choosing between construction-local endpoint names.
 - `src/order_maps.ac` now has `apply`, `le`/`lt`/`ge`/`gt` embedding, identity, and composition aliases for monotone, antitone, strict monotone, strict antitone, order embedding, and order surjection facts.
+- Numeric construction-local order names have been audited against the generic `PartialOrder` / `LinearOrder` API. The remaining unreplaced Nat names are genuinely successor- or arithmetic-specific rather than generic order facts.

--- a/projects/translate-mathlib/order-theory/complete-lattices/todo.md
+++ b/projects/translate-mathlib/order-theory/complete-lattices/todo.md
@@ -6,9 +6,14 @@ Goal: support arbitrary suprema and infima, not just binary ones.
 - [ ] Add `sup`, `inf`, `sSup`, and `sInf` APIs
 - [ ] Prove the standard order characterizations of arbitrary suprema and infima
 - [ ] Add monotonicity lemmas for `sSup` and `sInf`
-- [ ] Add complete lattice instances for sets and predicates
+- [ ] Add complete lattice APIs for predicates and bundled instances where the typeclass receiver supports them
 - [ ] Support complete sublattices and closure operators
 - [ ] Add least and greatest fixed point infrastructure based on completeness
 - [ ] Connect complete lattices to topology and measure-theoretic constructions
 - [ ] Add convenient finite-family specializations of complete-lattice theorems
 - [ ] Record which downstream libraries should be migrated once this exists
+
+Status:
+
+- `src/set_lattice.ac` now has unbundled set-family `set_sSup` / `set_sInf` wrappers over indexed union/intersection, with membership characterizations, least-upper-bound and greatest-lower-bound universal properties, and monotonicity lemmas.
+- A direct `Set[K]: PartialOrder` / `Lattice` instance attempt was avoided: Acorn currently rejects same-shape generic `Set[K]` typeclass receiver use while rendering `LTE.lte[Set[K]](...)`. The verified unbundled API keeps set complete-lattice facts usable without committing to an unstable instance design.

--- a/projects/translate-mathlib/order-theory/lattices/todo.md
+++ b/projects/translate-mathlib/order-theory/lattices/todo.md
@@ -2,11 +2,12 @@
 
 Goal: provide finite-infimum and finite-supremum structure for ordered objects.
 
-- [ ] Support lattices arising from sets, ideals, and subobjects
+- [ ] Support lattice APIs for ideals and subobjects
 - [ ] Refactor `min`/`max`-based proofs toward lattice language where appropriate
 
 Status:
 
+- `src/set_lattice.ac` now provides an unbundled lattice-style API for sets: binary `set_inf`/`set_sup`, membership characterizations, lower/upper-bound universal properties, commutativity, associativity, idempotence, empty/universal identities, absorption, and distributivity.
 - `src/lattice.ac` now has theorem wrappers for the left distributivity laws, right-sided distributivity lemmas, left-sided absorption variants, one-sided monotonicity lemmas, basic meet/join equality iff aliases, equality consequences, commutation and reversed-associativity lemmas, and Mathlib-style `inf`/`sup` theorem aliases.
 - `Nat`, `Int`, `Rat`, and `Real` now instantiate `DistribLattice` using their `min` and `max` operations.
 - `src/list/list_lattice.ac` now has non-empty list meet/join constructions, list lower/upper bound predicates, pointwise element-bound theorems, and universal-property characterizations of list meet/join as greatest lower bounds and least upper bounds.

--- a/src/set_lattice.ac
+++ b/src/set_lattice.ac
@@ -1,0 +1,481 @@
+from set import Set, set_ext, subset_refl, subset_trans, subset_antisymm,
+    union_contains_eq, intersection_contains_eq, sets_subset_union, sets_subset_contain_union,
+    sets_subset_intersection, set_supset_contains_intersection, union_comm, intersection_comm,
+    union_assoc, intersection_assoc, union_idemp, intersection_idemp, union_with_empty_is_self,
+    intersection_with_universal_is_self, union_with_universal_is_universal,
+    intersection_with_empty_is_empty, union_intersection_distrib, indexed_union,
+    indexed_intersection, indexed_union_contains_eq, indexed_union_contains_of_contains,
+    indexed_union_subset_of_family_subset, indexed_intersection_contains_eq,
+    indexed_intersection_contains_at, indexed_intersection_contains_of_forall,
+    indexed_intersection_superset_of_subset_family, indexed_union_monotone,
+    indexed_intersection_monotone
+
+/// The infimum of two sets.
+define set_inf[K](a: Set[K], b: Set[K]) -> Set[K] {
+    a.intersection(b)
+}
+
+/// The supremum of two sets.
+define set_sup[K](a: Set[K], b: Set[K]) -> Set[K] {
+    a.union(b)
+}
+
+/// Membership in a set infimum is membership in both sets.
+theorem set_inf_contains_eq[K](a: Set[K], b: Set[K], x: K) {
+    set_inf(a, b).contains(x) = (a.contains(x) and b.contains(x))
+} by {
+    intersection_contains_eq(a, b, x)
+}
+
+/// Membership in a set supremum is membership in at least one set.
+theorem set_sup_contains_eq[K](a: Set[K], b: Set[K], x: K) {
+    set_sup(a, b).contains(x) = (a.contains(x) or b.contains(x))
+} by {
+    union_contains_eq(a, b, x)
+}
+
+/// A set infimum is contained in its left argument.
+theorem set_inf_subset_left[K](a: Set[K], b: Set[K]) {
+    set_inf(a, b).subset(a)
+} by {
+    sets_subset_intersection(a, b)
+    a.intersection(b).subset(a)
+}
+
+/// A set infimum is contained in its right argument.
+theorem set_inf_subset_right[K](a: Set[K], b: Set[K]) {
+    set_inf(a, b).subset(b)
+} by {
+    sets_subset_intersection(a, b)
+    a.intersection(b).subset(b)
+}
+
+/// Every common subset is contained in the set infimum.
+theorem set_subset_inf_of_subset_left_right[K](c: Set[K], a: Set[K], b: Set[K]) {
+    c.subset(a) and c.subset(b) implies c.subset(set_inf(a, b))
+} by {
+    if c.subset(a) and c.subset(b) {
+        a.superset(c)
+        b.superset(c)
+        set_supset_contains_intersection(a, b, c)
+        a.intersection(b).superset(c)
+        c.subset(a.intersection(b))
+        c.subset(set_inf(a, b))
+    }
+}
+
+/// Containment in a set infimum is exactly containment in both arguments.
+theorem set_subset_inf_iff[K](c: Set[K], a: Set[K], b: Set[K]) {
+    c.subset(set_inf(a, b)) = (c.subset(a) and c.subset(b))
+} by {
+    if c.subset(set_inf(a, b)) {
+        set_inf_subset_left(a, b)
+        subset_trans(c, set_inf(a, b), a)
+        c.subset(a)
+        set_inf_subset_right(a, b)
+        subset_trans(c, set_inf(a, b), b)
+        c.subset(b)
+        c.subset(a) and c.subset(b)
+    }
+    if c.subset(a) and c.subset(b) {
+        set_subset_inf_of_subset_left_right(c, a, b)
+        c.subset(set_inf(a, b))
+    }
+    c.subset(set_inf(a, b)) = (c.subset(a) and c.subset(b))
+}
+
+/// The left argument is contained in a set supremum.
+theorem set_subset_sup_left[K](a: Set[K], b: Set[K]) {
+    a.subset(set_sup(a, b))
+} by {
+    sets_subset_union(a, b)
+    a.subset(a.union(b))
+}
+
+/// The right argument is contained in a set supremum.
+theorem set_subset_sup_right[K](a: Set[K], b: Set[K]) {
+    b.subset(set_sup(a, b))
+} by {
+    sets_subset_union(a, b)
+    b.subset(a.union(b))
+}
+
+/// A set supremum is contained in every common superset.
+theorem set_sup_subset_of_subset_left_right[K](a: Set[K], b: Set[K], c: Set[K]) {
+    a.subset(c) and b.subset(c) implies set_sup(a, b).subset(c)
+} by {
+    if a.subset(c) and b.subset(c) {
+        sets_subset_contain_union(a, b, c)
+        a.union(b).subset(c)
+        set_sup(a, b).subset(c)
+    }
+}
+
+/// A set supremum is contained in a set exactly when both arguments are contained in it.
+theorem set_sup_subset_iff[K](a: Set[K], b: Set[K], c: Set[K]) {
+    set_sup(a, b).subset(c) = (a.subset(c) and b.subset(c))
+} by {
+    if set_sup(a, b).subset(c) {
+        set_subset_sup_left(a, b)
+        subset_trans(a, set_sup(a, b), c)
+        a.subset(c)
+        set_subset_sup_right(a, b)
+        subset_trans(b, set_sup(a, b), c)
+        b.subset(c)
+        a.subset(c) and b.subset(c)
+    }
+    if a.subset(c) and b.subset(c) {
+        set_sup_subset_of_subset_left_right(a, b, c)
+        set_sup(a, b).subset(c)
+    }
+    set_sup(a, b).subset(c) = (a.subset(c) and b.subset(c))
+}
+
+/// Set infimum is commutative.
+theorem set_inf_comm[K](a: Set[K], b: Set[K]) {
+    set_inf(a, b) = set_inf(b, a)
+} by {
+    intersection_comm(a, b)
+}
+
+/// Set supremum is commutative.
+theorem set_sup_comm[K](a: Set[K], b: Set[K]) {
+    set_sup(a, b) = set_sup(b, a)
+} by {
+    union_comm(a, b)
+}
+
+/// Set infimum is associative.
+theorem set_inf_assoc[K](a: Set[K], b: Set[K], c: Set[K]) {
+    set_inf(a, set_inf(b, c)) = set_inf(set_inf(a, b), c)
+} by {
+    intersection_assoc(a, b, c)
+}
+
+/// Set supremum is associative.
+theorem set_sup_assoc[K](a: Set[K], b: Set[K], c: Set[K]) {
+    set_sup(a, set_sup(b, c)) = set_sup(set_sup(a, b), c)
+} by {
+    union_assoc(a, b, c)
+}
+
+/// Set infimum is idempotent.
+theorem set_inf_idem[K](s: Set[K]) {
+    set_inf(s, s) = s
+} by {
+    intersection_idemp(s)
+}
+
+/// Set supremum is idempotent.
+theorem set_sup_idem[K](s: Set[K]) {
+    set_sup(s, s) = s
+} by {
+    union_idemp(s)
+}
+
+/// The infimum with the universal set is the original set.
+theorem set_inf_universal_right[K](s: Set[K]) {
+    set_inf(s, Set[K].universal_set) = s
+} by {
+    intersection_with_universal_is_self(s)
+}
+
+/// The infimum with the universal set on the left is the original set.
+theorem set_inf_universal_left[K](s: Set[K]) {
+    set_inf(Set[K].universal_set, s) = s
+} by {
+    intersection_comm(Set[K].universal_set, s)
+    intersection_with_universal_is_self(s)
+}
+
+/// The supremum with the empty set is the original set.
+theorem set_sup_empty_right[K](s: Set[K]) {
+    set_sup(s, Set[K].empty_set) = s
+} by {
+    union_with_empty_is_self(s)
+}
+
+/// The supremum with the empty set on the left is the original set.
+theorem set_sup_empty_left[K](s: Set[K]) {
+    set_sup(Set[K].empty_set, s) = s
+} by {
+    union_comm(Set[K].empty_set, s)
+    union_with_empty_is_self(s)
+}
+
+/// The infimum with the empty set is empty.
+theorem set_inf_empty_right[K](s: Set[K]) {
+    set_inf(s, Set[K].empty_set) = Set[K].empty_set
+} by {
+    intersection_with_empty_is_empty(s)
+}
+
+/// The infimum with the empty set on the left is empty.
+theorem set_inf_empty_left[K](s: Set[K]) {
+    set_inf(Set[K].empty_set, s) = Set[K].empty_set
+} by {
+    intersection_comm(Set[K].empty_set, s)
+    intersection_with_empty_is_empty(s)
+}
+
+/// The supremum with the universal set is universal.
+theorem set_sup_universal_right[K](s: Set[K]) {
+    set_sup(s, Set[K].universal_set) = Set[K].universal_set
+} by {
+    union_with_universal_is_universal(s)
+}
+
+/// The supremum with the universal set on the left is universal.
+theorem set_sup_universal_left[K](s: Set[K]) {
+    set_sup(Set[K].universal_set, s) = Set[K].universal_set
+} by {
+    union_comm(Set[K].universal_set, s)
+    union_with_universal_is_universal(s)
+}
+
+/// Set infimum absorbs set supremum.
+theorem set_inf_sup_absorb[K](a: Set[K], b: Set[K]) {
+    set_inf(a, set_sup(a, b)) = a
+} by {
+    set_inf_subset_left(a, set_sup(a, b))
+    set_inf(a, set_sup(a, b)).subset(a)
+    set_subset_sup_left(a, b)
+    set_subset_inf_of_subset_left_right(a, a, set_sup(a, b))
+    a.subset(set_inf(a, set_sup(a, b)))
+    subset_antisymm(set_inf(a, set_sup(a, b)), a)
+}
+
+/// Set supremum absorbs set infimum.
+theorem set_sup_inf_absorb[K](a: Set[K], b: Set[K]) {
+    set_sup(a, set_inf(a, b)) = a
+} by {
+    set_subset_sup_left(a, set_inf(a, b))
+    a.subset(set_sup(a, set_inf(a, b)))
+    set_inf_subset_left(a, b)
+    set_sup_subset_of_subset_left_right(a, set_inf(a, b), a)
+    set_sup(a, set_inf(a, b)).subset(a)
+    subset_antisymm(set_sup(a, set_inf(a, b)), a)
+}
+
+/// Set infimum distributes over set supremum on the left.
+theorem set_inf_sup_distrib_left[K](a: Set[K], b: Set[K], c: Set[K]) {
+    set_inf(a, set_sup(b, c)) = set_sup(set_inf(a, b), set_inf(a, c))
+} by {
+    let u = set_inf(a, set_sup(b, c))
+    let v = set_sup(set_inf(a, b), set_inf(a, c))
+    forall(x: K) {
+        if u.contains(x) {
+            set_inf_contains_eq(a, set_sup(b, c), x)
+            a.contains(x)
+            set_sup(b, c).contains(x)
+            set_sup_contains_eq(b, c, x)
+            if b.contains(x) {
+                set_inf_contains_eq(a, b, x)
+                set_inf(a, b).contains(x)
+                set_sup_contains_eq(set_inf(a, b), set_inf(a, c), x)
+                v.contains(x)
+            } else {
+                c.contains(x)
+                set_inf_contains_eq(a, c, x)
+                set_inf(a, c).contains(x)
+                set_sup_contains_eq(set_inf(a, b), set_inf(a, c), x)
+                v.contains(x)
+            }
+        }
+        if v.contains(x) {
+            set_sup_contains_eq(set_inf(a, b), set_inf(a, c), x)
+            if set_inf(a, b).contains(x) {
+                set_inf_contains_eq(a, b, x)
+                a.contains(x)
+                b.contains(x)
+                set_sup_contains_eq(b, c, x)
+                set_sup(b, c).contains(x)
+                set_inf_contains_eq(a, set_sup(b, c), x)
+                u.contains(x)
+            } else {
+                set_inf(a, c).contains(x)
+                set_inf_contains_eq(a, c, x)
+                a.contains(x)
+                c.contains(x)
+                set_sup_contains_eq(b, c, x)
+                set_sup(b, c).contains(x)
+                set_inf_contains_eq(a, set_sup(b, c), x)
+                u.contains(x)
+            }
+        }
+        u.contains(x) = v.contains(x)
+    }
+    set_ext(u, v)
+}
+
+/// Set supremum distributes over set infimum on the left.
+theorem set_sup_inf_distrib_left[K](a: Set[K], b: Set[K], c: Set[K]) {
+    set_sup(a, set_inf(b, c)) = set_inf(set_sup(a, b), set_sup(a, c))
+} by {
+    union_intersection_distrib(a, b, c)
+}
+
+/// The supremum of an indexed family of sets.
+define set_sSup[K, I](family: I -> Set[K]) -> Set[K] {
+    indexed_union(family)
+}
+
+/// The infimum of an indexed family of sets.
+define set_sInf[K, I](family: I -> Set[K]) -> Set[K] {
+    indexed_intersection(family)
+}
+
+/// Membership in the supremum of a family is membership in some member.
+theorem set_sSup_contains_eq[K, I](family: I -> Set[K], x: K) {
+    set_sSup(family).contains(x) = exists(i: I) {
+        family(i).contains(x)
+    }
+} by {
+    indexed_union_contains_eq(family, x)
+}
+
+/// Membership in the infimum of a family is membership in every member.
+theorem set_sInf_contains_eq[K, I](family: I -> Set[K], x: K) {
+    set_sInf(family).contains(x) = forall(i: I) {
+        family(i).contains(x)
+    }
+} by {
+    indexed_intersection_contains_eq(family, x)
+}
+
+/// Every member of a family is contained in the supremum of that family.
+theorem set_family_subset_sSup[K, I](family: I -> Set[K], i: I) {
+    family(i).subset(set_sSup(family))
+} by {
+    forall(x: K) {
+        if family(i).contains(x) {
+            indexed_union_contains_of_contains(family, i, x)
+            set_sSup(family).contains(x)
+        }
+    }
+}
+
+/// The supremum of a family is contained in every common superset.
+theorem set_sSup_subset_of_family_subset[K, I](family: I -> Set[K], s: Set[K]) {
+    (forall(i: I) { family(i).subset(s) }) implies set_sSup(family).subset(s)
+} by {
+    if forall(i: I) { family(i).subset(s) } {
+        indexed_union_subset_of_family_subset(family, s)
+        set_sSup(family).subset(s)
+    }
+}
+
+/// The supremum of a family is contained in a set exactly when every member is contained in it.
+theorem set_sSup_subset_iff[K, I](family: I -> Set[K], s: Set[K]) {
+    set_sSup(family).subset(s) = forall(i: I) {
+        family(i).subset(s)
+    }
+} by {
+    if set_sSup(family).subset(s) {
+        forall(i: I) {
+            set_family_subset_sSup(family, i)
+            subset_trans(family(i), set_sSup(family), s)
+            family(i).subset(s)
+        }
+    }
+    if forall(i: I) { family(i).subset(s) } {
+        set_sSup_subset_of_family_subset(family, s)
+        set_sSup(family).subset(s)
+    }
+    set_sSup(family).subset(s) = forall(i: I) {
+        family(i).subset(s)
+    }
+}
+
+/// The infimum of a family is contained in every member of the family.
+theorem set_sInf_subset_family[K, I](family: I -> Set[K], i: I) {
+    set_sInf(family).subset(family(i))
+} by {
+    forall(x: K) {
+        if set_sInf(family).contains(x) {
+            indexed_intersection_contains_at(family, i, x)
+            family(i).contains(x)
+        }
+    }
+}
+
+/// Every common subset is contained in the infimum of a family.
+theorem set_subset_sInf_of_subset_family[K, I](s: Set[K], family: I -> Set[K]) {
+    (forall(i: I) { s.subset(family(i)) }) implies s.subset(set_sInf(family))
+} by {
+    if forall(i: I) { s.subset(family(i)) } {
+        indexed_intersection_superset_of_subset_family(family, s)
+        indexed_intersection(family).superset(s)
+        s.subset(set_sInf(family))
+    }
+}
+
+/// A set is contained in the infimum of a family exactly when it is contained in every member.
+theorem set_subset_sInf_iff[K, I](s: Set[K], family: I -> Set[K]) {
+    s.subset(set_sInf(family)) = forall(i: I) {
+        s.subset(family(i))
+    }
+} by {
+    if s.subset(set_sInf(family)) {
+        forall(i: I) {
+            set_sInf_subset_family(family, i)
+            subset_trans(s, set_sInf(family), family(i))
+            s.subset(family(i))
+        }
+    }
+    if forall(i: I) { s.subset(family(i)) } {
+        set_subset_sInf_of_subset_family(s, family)
+        s.subset(set_sInf(family))
+    }
+    s.subset(set_sInf(family)) = forall(i: I) {
+        s.subset(family(i))
+    }
+}
+
+/// Pointwise inclusion of families preserves family suprema.
+theorem set_sSup_monotone[K, I](a: I -> Set[K], b: I -> Set[K]) {
+    (forall(i: I) { a(i).subset(b(i)) }) implies set_sSup(a).subset(set_sSup(b))
+} by {
+    if forall(i: I) { a(i).subset(b(i)) } {
+        indexed_union_monotone(a, b)
+        indexed_union(a).subset(indexed_union(b))
+        set_sSup(a) = indexed_union(a)
+        set_sSup(b) = indexed_union(b)
+        set_sSup(a).subset(set_sSup(b))
+    }
+}
+
+/// Pointwise inclusion of families preserves family infima.
+theorem set_sInf_monotone[K, I](a: I -> Set[K], b: I -> Set[K]) {
+    (forall(i: I) { a(i).subset(b(i)) }) implies set_sInf(a).subset(set_sInf(b))
+} by {
+    if forall(i: I) { a(i).subset(b(i)) } {
+        indexed_intersection_monotone(a, b)
+        indexed_intersection(a).subset(indexed_intersection(b))
+        set_sInf(a) = indexed_intersection(a)
+        set_sInf(b) = indexed_intersection(b)
+        set_sInf(a).subset(set_sInf(b))
+    }
+}
+
+/// A family supremum is the least upper bound of the family.
+theorem set_sSup_is_lub[K, I](family: I -> Set[K], s: Set[K]) {
+    (forall(i: I) { family(i).subset(set_sSup(family)) }) and
+    (set_sSup(family).subset(s) = forall(i: I) { family(i).subset(s) })
+} by {
+    forall(i: I) {
+        set_family_subset_sSup(family, i)
+    }
+    set_sSup_subset_iff(family, s)
+}
+
+/// A family infimum is the greatest lower bound of the family.
+theorem set_sInf_is_glb[K, I](family: I -> Set[K], s: Set[K]) {
+    (forall(i: I) { set_sInf(family).subset(family(i)) }) and
+    (s.subset(set_sInf(family)) = forall(i: I) { s.subset(family(i)) })
+} by {
+    forall(i: I) {
+        set_sInf_subset_family(family, i)
+    }
+    set_subset_sInf_iff(s, family)
+}


### PR DESCRIPTION
## Summary
- add `src/set_lattice.ac` with unbundled set infimum/supremum wrappers over intersection/union
- prove membership, universal-property, commutativity, associativity, idempotence, identity, absorption, distributivity, and family `set_sSup`/`set_sInf` lemmas
- update translate-mathlib order-theory roadmap entries for the verified set-lattice API and remaining bundled-instance work

## Test Plan
- `acorn check`
